### PR TITLE
Add handling for a different Fn+R key value

### DIFF
--- a/LenovoLegionToolkit.Lib/Enums.cs
+++ b/LenovoLegionToolkit.Lib/Enums.cs
@@ -156,7 +156,8 @@ namespace LenovoLegionToolkit.Lib
         Fn_LockOn = 2,
         Fn_LockOff = 3,
         Fn_PrtSc = 4,
-        Fn_R = 16
+        Fn_R = 16,
+        Fn_R_2 = 0x0041002A,
     }
 
     public enum Theme

--- a/LenovoLegionToolkit.Lib/Listeners/SpecialKeyListener.cs
+++ b/LenovoLegionToolkit.Lib/Listeners/SpecialKeyListener.cs
@@ -30,7 +30,7 @@ namespace LenovoLegionToolkit.Lib.Listeners
 
         protected override Task OnChangedAsync(SpecialKey value)
         {
-            if (value == SpecialKey.Fn_R)
+            if (value == SpecialKey.Fn_R || value == SpecialKey.Fn_R_2)
                 return ToggleRefreshRateAsync();
 
             if (value == SpecialKey.Fn_PrtSc)


### PR DESCRIPTION
On my Legion 5 2021 (which usually only lists 165hz in the display settings, but 60hz can be added with CRU), pressing Fn+R sends the PressTypeDataVal `0x0041002A`.

Some community testing may be needed to see if this value is applicable to other similar laptops.