### PR TITLE
Fix ACAdapter triggers

### DIFF
--- a/LenovoLegionToolkit.Lib.Automation/Pipeline/Triggers/ACAdapterConnectedAutomationPipelineTrigger.cs
+++ b/LenovoLegionToolkit.Lib.Automation/Pipeline/Triggers/ACAdapterConnectedAutomationPipelineTrigger.cs
@@ -12,7 +12,7 @@ namespace LenovoLegionToolkit.Lib.Automation.Pipeline.Triggers
 
         public async Task<bool> IsSatisfiedAsync(IAutomationEvent automationEvent)
         {
-            if (automationEvent is not PowerAutomationEvent || automationEvent is not StartupAutomationEvent)
+            if (automationEvent is not (PowerAutomationEvent or StartupAutomationEvent))
                 return false;
 
             return await Power.IsPowerAdapterConnectedAsync().ConfigureAwait(false) == PowerAdapterStatus.Connected;

--- a/LenovoLegionToolkit.Lib.Automation/Pipeline/Triggers/ACAdapterDisconnectedAutomationPipelineTrigger.cs
+++ b/LenovoLegionToolkit.Lib.Automation/Pipeline/Triggers/ACAdapterDisconnectedAutomationPipelineTrigger.cs
@@ -12,7 +12,7 @@ namespace LenovoLegionToolkit.Lib.Automation.Pipeline.Triggers
 
         public async Task<bool> IsSatisfiedAsync(IAutomationEvent automationEvent)
         {
-            if (automationEvent is not PowerAutomationEvent || automationEvent is not StartupAutomationEvent)
+            if (automationEvent is not (PowerAutomationEvent or StartupAutomationEvent))
                 return false;
 
             return await Power.IsPowerAdapterConnectedAsync().ConfigureAwait(false) == PowerAdapterStatus.Disconnected;


### PR DESCRIPTION
Should've been `(automationEvent is not PowerAutomationEvent && automationEvent is not StartupAutomationEvent)`, but there's an even nicer way of checking it.