### PR TITLE
Use system accent color

### DIFF
--- a/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
@@ -10,6 +10,7 @@ namespace LenovoLegionToolkit.Lib.Settings
             public WindowSize WindowSize { get; set; }
             public Theme Theme { get; set; }
             public RGBColor? AccentColor { get; set; }
+            public bool SystemAccentColor { get; set; }
             public Dictionary<PowerModeState, string> PowerPlans { get; set; } = new();
             public bool MinimizeOnClose { get; set; }
             public bool ActivatePowerProfilesWithVantageEnabled { get; set; }

--- a/LenovoLegionToolkit.WPF/Controls/ColorCardControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/ColorCardControl.cs
@@ -5,7 +5,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using ColorPicker;
 using LenovoLegionToolkit.Lib;
-using LenovoLegionToolkit.WPF.Utils;
 using Wpf.Ui.Common;
 using Wpf.Ui.Controls;
 using Button = System.Windows.Controls.Button;
@@ -15,8 +14,6 @@ namespace LenovoLegionToolkit.WPF.Controls
 {
     public class ColorCardControl : UserControl
     {
-        private readonly ThemeManager _themeManager = IoCContainer.Resolve<ThemeManager>();
-
         private readonly CardExpander _cardExpander = new();
 
         private readonly CardHeaderControl _cardHeaderControl = new();
@@ -102,33 +99,6 @@ namespace LenovoLegionToolkit.WPF.Controls
             Margin = new(0, 8, 0, 0),
         };
 
-        private readonly Grid _systemAccentColorGrid = new()
-        {
-            ColumnDefinitions =
-            {
-                new() { Width = GridLength.Auto },
-                new() { Width = new(16, GridUnitType.Pixel) },
-                new() { Width = new(1, GridUnitType.Star) },
-            },
-            RowDefinitions =
-            {
-                new() { Height = GridLength.Auto },
-            },
-        };
-
-        private readonly Label _systemAccentColorLabel = new()
-        {
-            Content = "System Accent Color:",
-            VerticalContentAlignment = VerticalAlignment.Center,
-            Margin = new(0, 8, 0, 0),
-        };
-
-        private readonly CheckBox _systemAccentColorCheckBox = new()
-        {
-            IsChecked = false,
-            Margin = new(0, 8, 0, 0),
-        };
-
         public SymbolRegular Icon
         {
             get => _cardExpander.Icon;
@@ -158,9 +128,6 @@ namespace LenovoLegionToolkit.WPF.Controls
             _greenTextBox.TextChanged += ColorTextBox_TextChanged;
             _blueTextBox.TextChanged += ColorTextBox_TextChanged;
             _colorPicker.MouseUp += ColorsPanel_MouseUp;
-            _systemAccentColorCheckBox.Checked += SystemAccentColor_Checked;
-            _systemAccentColorCheckBox.Unchecked += SystemAccentColor_Unchecked;
-
 
             _colorButton.Click += (s, e) => _cardExpander.IsExpanded = !_cardExpander.IsExpanded;
             _cardHeaderControl.Accessory = _colorButton;
@@ -186,28 +153,13 @@ namespace LenovoLegionToolkit.WPF.Controls
             _rgbGrid.Children.Add(_greenTextBox);
             _rgbGrid.Children.Add(_blueTextBox);
 
-            Grid.SetColumn(_systemAccentColorLabel, 0);
-            Grid.SetColumn(_systemAccentColorCheckBox, 2);
-
-            Grid.SetRow(_systemAccentColorLabel, 0);
-            Grid.SetRow(_systemAccentColorCheckBox, 0);
-
-            _systemAccentColorGrid.Children.Add(_systemAccentColorLabel);
-            _systemAccentColorGrid.Children.Add(_systemAccentColorCheckBox);
-
             _colorsPanel.Children.Add(_colorPicker);
             _colorsPanel.Children.Add(_rgbGrid);
-            _colorsPanel.Children.Add(_systemAccentColorGrid);
 
             _cardExpander.Header = _cardHeaderControl;
             _cardExpander.Content = _colorsPanel;
 
             Content = _cardExpander;
-
-            if (Color.Equals(_colorButton.Background, ((SolidColorBrush)SystemParameters.WindowGlassBrush).Color))
-                _systemAccentColorCheckBox.IsChecked = true;
-            else
-                _systemAccentColorCheckBox.IsChecked = false;
         }
 
         private void ColorTextBox_TextChanged(object sender, TextChangedEventArgs e)
@@ -228,11 +180,6 @@ namespace LenovoLegionToolkit.WPF.Controls
 
             if (Mouse.LeftButton == MouseButtonState.Released && Mouse.RightButton == MouseButtonState.Released)
                 OnChanged?.Invoke(this, EventArgs.Empty);
-
-            if (!Color.Equals(color, ((SolidColorBrush)SystemParameters.WindowGlassBrush).Color))
-                _systemAccentColorCheckBox.IsChecked = false;
-            else
-                _systemAccentColorCheckBox.IsChecked = true;
         }
 
         private void ColorPicker_ColorChanged(object sender, RoutedEventArgs e)
@@ -247,36 +194,6 @@ namespace LenovoLegionToolkit.WPF.Controls
         private void ColorsPanel_MouseUp(object sender, MouseButtonEventArgs e)
         {
             OnChanged?.Invoke(this, EventArgs.Empty);
-        }
-
-        private void SystemAccentColor_Checked(object sender, RoutedEventArgs e)
-        {
-            Color systemAccentColor = ((SolidColorBrush)SystemParameters.WindowGlassBrush).Color;
-            if (Color.Equals(systemAccentColor, _colorPicker.SelectedColor))
-                return;
-
-            _colorPicker.SelectedColor = Color.FromRgb(systemAccentColor.R, systemAccentColor.G, systemAccentColor.B);
-
-            _systemAccentColorCheckBox.IsChecked = true;
-
-            if (Mouse.LeftButton == MouseButtonState.Released && Mouse.RightButton == MouseButtonState.Released)
-                OnChanged?.Invoke(this, EventArgs.Empty);
-        }
-
-        private void SystemAccentColor_Unchecked(object sender, RoutedEventArgs e)
-        {
-            Color accentColor = Color.FromRgb(
-                _themeManager.DefaultAccentColor.R,
-                _themeManager.DefaultAccentColor.G,
-                _themeManager.DefaultAccentColor.B);
-
-            _colorPicker.SelectedColor = Color.FromRgb(
-                accentColor.R,
-                accentColor.G,
-                accentColor.B);
-
-            if (Mouse.LeftButton == MouseButtonState.Released && Mouse.RightButton == MouseButtonState.Released)
-                OnChanged?.Invoke(this, EventArgs.Empty);
         }
 
         public void SetColor(RGBColor color)

--- a/LenovoLegionToolkit.WPF/IoCModule.cs
+++ b/LenovoLegionToolkit.WPF/IoCModule.cs
@@ -9,6 +9,7 @@ namespace LenovoLegionToolkit.WPF
         protected override void Load(ContainerBuilder builder)
         {
             builder.Register<ThemeManager>();
+            builder.Register<SystemAccentColorHelper>();
 
             builder.Register<NotificationsManager>().AutoActivate();
         }

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml
@@ -36,10 +36,21 @@
         <controls:ColorCardControl
             x:Name="_accentColor"
             Title="Accent color"
-            Margin="0,0,0,24"
+            Margin="0,0,0,8"
             Icon="Color24"
             OnChanged="AccentColorControl_OnChanged"
             Subtitle="Change the accent color of the app." />
+
+        <wpfui:CardControl Margin="0,0,0,24">
+            <wpfui:CardControl.Header>
+                <controls:CardHeaderControl Title="Use System Accent Color" Subtitle="Use the system accent color in the app.&#x0a;Toggle off the specify the app accent color with the accent color toggle above." />
+            </wpfui:CardControl.Header>
+            <wpfui:ToggleSwitch
+                x:Name="_systemAccentColorToggle"
+                Margin="0,0,0,8"
+                Click="SystemAccentColorToggle_Click"
+                Visibility="Hidden" />
+        </wpfui:CardControl>
 
         <wpfui:CardControl Margin="0,0,0,8">
             <wpfui:CardControl.Header>

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using LenovoLegionToolkit.Lib;
 using LenovoLegionToolkit.Lib.Controllers;
 using LenovoLegionToolkit.Lib.Settings;
@@ -19,6 +20,7 @@ namespace LenovoLegionToolkit.WPF.Pages
         private readonly FnKeys _fnKeys = IoCContainer.Resolve<FnKeys>();
         private readonly RGBKeyboardBacklightController _rgbKeyboardBacklightController = IoCContainer.Resolve<RGBKeyboardBacklightController>();
         private readonly ThemeManager _themeManager = IoCContainer.Resolve<ThemeManager>();
+        private readonly SystemAccentColorHelper _systemAccentColorHelper = IoCContainer.Resolve<SystemAccentColorHelper>();
 
         private bool _isRefreshing;
 
@@ -46,6 +48,7 @@ namespace LenovoLegionToolkit.WPF.Pages
 
             _themeComboBox.SetItems(Enum.GetValues<Theme>(), _settings.Store.Theme);
             _accentColor.SetColor(_settings.Store.AccentColor ?? _themeManager.DefaultAccentColor);
+            _systemAccentColorToggle.IsChecked = _settings.Store.SystemAccentColor;
             _autorunToggle.IsChecked = Autorun.IsEnabled;
             _minimizeOnCloseToggle.IsChecked = _settings.Store.MinimizeOnClose;
 
@@ -65,6 +68,7 @@ namespace LenovoLegionToolkit.WPF.Pages
             await loadingTask;
 
             _themeComboBox.Visibility = Visibility.Visible;
+            _systemAccentColorToggle.Visibility = Visibility.Visible;
             _autorunToggle.Visibility = Visibility.Visible;
             _minimizeOnCloseToggle.Visibility = Visibility.Visible;
             _vantageToggle.Visibility = Visibility.Visible;
@@ -97,6 +101,32 @@ namespace LenovoLegionToolkit.WPF.Pages
             _settings.SynchronizeStore();
 
             _themeManager.Apply();
+        }
+
+        private void SystemAccentColorToggle_Click(object sender, RoutedEventArgs e)
+        {
+            if (_isRefreshing)
+                return;
+
+            var state = _systemAccentColorToggle.IsChecked;
+            if (state is null)
+                return;
+
+            if (state.Value)
+            {
+                _systemAccentColorHelper.Apply();
+                _accentColor.SetColor(_systemAccentColorHelper.SystemAccentColor);
+                _settings.Store.AccentColor = _accentColor.GetColor();
+                _settings.Store.SystemAccentColor = state.Value;
+                _settings.SynchronizeStore();
+            }
+            else
+            {
+                _accentColor.SetColor(_themeManager.DefaultAccentColor);
+                _settings.Store.AccentColor = _accentColor.GetColor();
+                _settings.Store.SystemAccentColor = state.Value;
+                _settings.SynchronizeStore();
+            }
         }
 
         private void AutorunToggle_Click(object sender, RoutedEventArgs e)

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
@@ -10,6 +10,7 @@ using LenovoLegionToolkit.Lib.System;
 using LenovoLegionToolkit.Lib.Utils;
 using LenovoLegionToolkit.WPF.Utils;
 using LenovoLegionToolkit.WPF.Windows.Settings;
+using static System.Windows.Forms.AxHost;
 
 namespace LenovoLegionToolkit.WPF.Pages
 {
@@ -97,9 +98,21 @@ namespace LenovoLegionToolkit.WPF.Pages
             if (_isRefreshing)
                 return;
 
+            bool isSystemAccentColor = RGBColor.Equals(_accentColor.GetColor(), _systemAccentColorHelper.SystemAccentColor);
+            if (isSystemAccentColor)
+            {
+                _settings.Store.SystemAccentColor = true;
+            }
+            else
+            {
+                _settings.Store.SystemAccentColor = false;
+            }
+
+            _systemAccentColorToggle.IsChecked = _settings.Store.SystemAccentColor;
+
             _settings.Store.AccentColor = _accentColor.GetColor();
             _settings.SynchronizeStore();
-
+            
             _themeManager.Apply();
         }
 
@@ -114,16 +127,13 @@ namespace LenovoLegionToolkit.WPF.Pages
 
             if (state.Value)
             {
-                _systemAccentColorHelper.Apply();
                 _accentColor.SetColor(_systemAccentColorHelper.SystemAccentColor);
-                _settings.Store.AccentColor = _accentColor.GetColor();
                 _settings.Store.SystemAccentColor = state.Value;
                 _settings.SynchronizeStore();
             }
             else
             {
                 _accentColor.SetColor(_themeManager.DefaultAccentColor);
-                _settings.Store.AccentColor = _accentColor.GetColor();
                 _settings.Store.SystemAccentColor = state.Value;
                 _settings.SynchronizeStore();
             }

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 using LenovoLegionToolkit.Lib;
 using LenovoLegionToolkit.Lib.Controllers;
 using LenovoLegionToolkit.Lib.Settings;
@@ -10,7 +9,6 @@ using LenovoLegionToolkit.Lib.System;
 using LenovoLegionToolkit.Lib.Utils;
 using LenovoLegionToolkit.WPF.Utils;
 using LenovoLegionToolkit.WPF.Windows.Settings;
-using static System.Windows.Forms.AxHost;
 
 namespace LenovoLegionToolkit.WPF.Pages
 {

--- a/LenovoLegionToolkit.WPF/Utils/SystemAccentColorHelper.cs
+++ b/LenovoLegionToolkit.WPF/Utils/SystemAccentColorHelper.cs
@@ -22,17 +22,6 @@ namespace LenovoLegionToolkit.WPF.Utils
                     ((SolidColorBrush)SystemParameters.WindowGlassBrush).Color.G,
                     ((SolidColorBrush)SystemParameters.WindowGlassBrush).Color.B);
 
-        public bool IsSystemAccentColor
-        {
-            get
-            {
-                var accentColor = _settings.Store.AccentColor;
-                var systemAccentColor = ((SolidColorBrush)SystemParameters.WindowGlassBrush).Color;
-                var isSystemAccentColor = Color.Equals(systemAccentColor, accentColor);
-                return isSystemAccentColor;
-            }
-        }
-
         public event EventHandler? AccentColorApplied;
         
         public SystemAccentColorHelper(ApplicationSettings settings)

--- a/LenovoLegionToolkit.WPF/Utils/SystemAccentColorHelper.cs
+++ b/LenovoLegionToolkit.WPF/Utils/SystemAccentColorHelper.cs
@@ -1,0 +1,67 @@
+﻿using LenovoLegionToolkit.Lib.Settings;
+using System;
+using System.Windows.Media;
+using System.Windows;
+using LenovoLegionToolkit.Lib;
+using LenovoLegionToolkit.Lib.System;
+
+namespace LenovoLegionToolkit.WPF.Utils
+{
+    public class SystemAccentColorHelper
+    {
+        private const string RegistryHive = "HKEY_CURRENT_USER";
+        private const string RegistryPath = @"Software\Microsoft\Windows\DWM";
+        private const string RegistryKey = "AccentColor";
+        
+        private readonly ApplicationSettings _settings;
+
+        private readonly IDisposable _systemAccentColorListener;
+
+        public RGBColor SystemAccentColor => new
+                    (((SolidColorBrush)SystemParameters.WindowGlassBrush).Color.R,
+                    ((SolidColorBrush)SystemParameters.WindowGlassBrush).Color.G,
+                    ((SolidColorBrush)SystemParameters.WindowGlassBrush).Color.B);
+
+        public bool IsSystemAccentColor
+        {
+            get
+            {
+                var accentColor = _settings.Store.AccentColor;
+                var systemAccentColor = ((SolidColorBrush)SystemParameters.WindowGlassBrush).Color;
+                var isSystemAccentColor = Color.Equals(systemAccentColor, accentColor);
+                return isSystemAccentColor;
+            }
+        }
+
+        public event EventHandler? AccentColorApplied;
+        
+        public SystemAccentColorHelper(ApplicationSettings settings)
+        {
+            _settings = settings;
+            _systemAccentColorListener = Registry.Listen(RegistryHive, RegistryPath, RegistryKey, () => Application.Current.Dispatcher.Invoke(Apply));
+        }
+
+        public void Apply()
+        {
+            SetSystemAccentColor();
+            AccentColorApplied?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void SetSystemAccentColor()
+        {
+            SetColor(SystemAccentColor);
+            _settings.Store.AccentColor = SystemAccentColor;
+            _settings.SynchronizeStore();
+        }
+
+        private void SetColor(RGBColor color)
+        {
+            var accentColorRgb = color;
+            var accentColor = Color.FromRgb(accentColorRgb.R, accentColorRgb.G, accentColorRgb.B);
+            Wpf.Ui.Appearance.Accent.Apply(systemAccent: accentColor,
+                primaryAccent: accentColor,
+                secondaryAccent: accentColor,
+                tertiaryAccent: accentColor);
+        }
+    }
+}


### PR DESCRIPTION
Option to allow app accent color to use system accent color. This will address part of the feature request in issue #200.

Need to add some more logic if we want to follow the system accent color.