### PR TITLE
Match system accent color & minor fixes

### DIFF
--- a/LenovoLegionToolkit.Lib/Controllers/RGBKeyboardBacklightController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/RGBKeyboardBacklightController.cs
@@ -141,86 +141,19 @@ namespace LenovoLegionToolkit.Lib.Controllers
 
         public async Task SetPresetAsync(RGBKeyboardBacklightPreset preset)
         {
-            using (await _ioLock.LockAsync().ConfigureAwait(false))
-            {
-#if !MOCK_RGB
-                var handle = DriverHandle;
-                if (handle is null)
-                    throw new InvalidOperationException("RGB Keyboard unsupported.");
-#endif
-
-                await ThrowIfVantageEnabled().ConfigureAwait(false);
-
-                var state = _settings.Store.State;
-                var presets = state.Presets;
-
-                _settings.Store.State = new(preset, presets);
-                _settings.SynchronizeStore();
-
-                RGBKeyboardStateEx str;
-                if (preset == RGBKeyboardBacklightPreset.Off)
-                    str = CreateOffState();
-                else
-                    str = Convert(state.Presets[preset]);
-
-                await SendToDevice(str).ConfigureAwait(false);
-            }
+            await SetStateAsync(new(preset, _settings.Store.State.Presets)).ConfigureAwait(false);
         }
 
         public async Task SetNextPresetAsync()
         {
-            using (await _ioLock.LockAsync().ConfigureAwait(false))
-            {
-#if !MOCK_RGB
-                var handle = DriverHandle;
-                if (handle is null)
-                    throw new InvalidOperationException("RGB Keyboard unsupported.");
-#endif
-
-                await ThrowIfVantageEnabled().ConfigureAwait(false);
-
-                var state = _settings.Store.State;
-
-                var newPreset = state.SelectedPreset.Next();
-                var presets = state.Presets;
-
-                _settings.Store.State = new(newPreset, presets);
-                _settings.SynchronizeStore();
-
-                RGBKeyboardStateEx str;
-                if (newPreset == RGBKeyboardBacklightPreset.Off)
-                    str = CreateOffState();
-                else
-                    str = Convert(state.Presets[newPreset]);
-
-                await SendToDevice(str).ConfigureAwait(false);
-            }
+            await SetPresetAsync(_settings.Store.State.SelectedPreset.Next()).ConfigureAwait(false);
         }
 
         private async Task SetCurrentPresetAsync()
         {
-            using (await _ioLock.LockAsync().ConfigureAwait(false))
-            {
-#if !MOCK_RGB
-                var handle = DriverHandle;
-                if (handle is null)
-                    throw new InvalidOperationException("RGB Keyboard unsupported.");
-#endif
+            await SetPresetAsync(_settings.Store.State.SelectedPreset).ConfigureAwait(false);
 
-                await ThrowIfVantageEnabled().ConfigureAwait(false);
 
-                var state = _settings.Store.State;
-
-                var preset = state.SelectedPreset;
-
-                RGBKeyboardStateEx str;
-                if (preset == RGBKeyboardBacklightPreset.Off)
-                    str = CreateOffState();
-                else
-                    str = Convert(state.Presets[preset]);
-
-                await SendToDevice(str).ConfigureAwait(false);
-            }
         }
 
         private async Task ThrowIfVantageEnabled()

--- a/LenovoLegionToolkit.Lib/IoCModule.cs
+++ b/LenovoLegionToolkit.Lib/IoCModule.cs
@@ -61,6 +61,9 @@ namespace LenovoLegionToolkit.Lib
             builder.Register<WinKeyListener>()
                 .OnActivating(e => e.Instance.StartAsync())
                 .AutoActivate();
+            builder.Register<SystemThemeListener>()
+                .OnActivating(e => e.Instance.StartAsync())
+                .AutoActivate();
 
             builder.Register<GPUController>();
             builder.Register<CPUBoostModeController>();

--- a/LenovoLegionToolkit.Lib/Listeners/SystemThemeListener.cs
+++ b/LenovoLegionToolkit.Lib/Listeners/SystemThemeListener.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using LenovoLegionToolkit.Lib.System;
+using Octokit;
+
+namespace LenovoLegionToolkit.Lib.Listeners
+{
+    public class SystemThemeListener : IListener<SystemThemeSettings>
+    {
+        public event EventHandler<SystemThemeSettings>? Changed;
+
+        private IDisposable? _darkModeListener, _accentColorListener;
+
+        private RGBColor? _currentColor;
+
+        private bool _started;
+
+        public Task StartAsync()
+        {
+            if (_started)
+                return Task.CompletedTask;
+
+            _darkModeListener = SystemTheme.GetDarkModeListener(InvokeChangedEvent);
+            _accentColorListener = SystemTheme.GetAccentColorListener(() =>
+            {
+                var color = SystemTheme.GetAccentColor();
+
+                // Ignore alpha channel transition events
+                if (_currentColor.Equals(color))
+                    return;
+
+                _currentColor = color;
+
+                InvokeChangedEvent();
+            });
+
+            _started = true;
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync()
+        {
+            _darkModeListener?.Dispose();
+            _accentColorListener?.Dispose();
+
+            _started = false;
+
+            return Task.CompletedTask;
+        }
+
+        private void InvokeChangedEvent()
+        {
+            Changed?.Invoke(this, new(SystemTheme.GetDarkMode(), _currentColor ?? SystemTheme.GetAccentColor()));
+        }
+    }
+}

--- a/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
@@ -23,7 +23,7 @@ namespace LenovoLegionToolkit.Lib.Settings
 
         public override ApplicationSettingsStore Default => new()
         {
-            Theme = Theme.Dark,
+            Theme = Theme.System,
             SyncSystemAccentColor = true,
             TemperatureUnit = TemperatureUnit.C,
         };

--- a/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
@@ -10,6 +10,7 @@ namespace LenovoLegionToolkit.Lib.Settings
             public WindowSize WindowSize { get; set; }
             public Theme Theme { get; set; }
             public RGBColor? AccentColor { get; set; }
+            public bool SyncSystemAccentColor { get; set; }
             public Dictionary<PowerModeState, string> PowerPlans { get; set; } = new();
             public bool MinimizeOnClose { get; set; }
             public bool ActivatePowerProfilesWithVantageEnabled { get; set; }
@@ -23,6 +24,7 @@ namespace LenovoLegionToolkit.Lib.Settings
         public override ApplicationSettingsStore Default => new()
         {
             Theme = Theme.Dark,
+            SyncSystemAccentColor = true,
             TemperatureUnit = TemperatureUnit.C,
         };
     }

--- a/LenovoLegionToolkit.Lib/Settings/RGBKeyboardSettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/RGBKeyboardSettings.cs
@@ -14,9 +14,14 @@ namespace LenovoLegionToolkit.Lib.Settings
         public override RGBKeyboardSettingsStore Default => new()
         {
             State = new(RGBKeyboardBacklightPreset.Off, new Dictionary<RGBKeyboardBacklightPreset, RGBKeyboardBacklightSettings> {
-                 { RGBKeyboardBacklightPreset.One, new(RGBKeyboardEffect.Static, RBGKeyboardSpeed.Slowest, RGBKeyboardBrightness.Low, new(142, 255, 0), new(0, 212, 255), new(101, 0, 255), new(186, 0, 255)) },
-                 { RGBKeyboardBacklightPreset.Two, new(RGBKeyboardEffect.Breath, RBGKeyboardSpeed.Slowest, RGBKeyboardBrightness.Low, new(255, 255, 255), new(255,255,255), new(255,255,255), new (255,255,255)) },
-                 { RGBKeyboardBacklightPreset.Three, new(RGBKeyboardEffect.Smooth, RBGKeyboardSpeed.Slowest, RGBKeyboardBrightness.Low, new(255, 255, 255), new(255,255,255), new(255,255,255), new (255,255,255)) },
+                 { RGBKeyboardBacklightPreset.One, new(RGBKeyboardEffect.Static, RBGKeyboardSpeed.Slowest, RGBKeyboardBrightness.Low,
+                     new(new(142, 255, 0), false), new(new(0, 212, 255), false), new(new(101, 0, 255), false), new(new(186, 0, 255), false)) },
+
+                 { RGBKeyboardBacklightPreset.Two, new(RGBKeyboardEffect.Breath, RBGKeyboardSpeed.Slowest, RGBKeyboardBrightness.Low,
+                     new(new(255, 255, 255), false), new(new(255,255,255), false), new(new(255,255,255), false), new(new(255,255,255), false)) },
+
+                 { RGBKeyboardBacklightPreset.Three, new(RGBKeyboardEffect.Smooth, RBGKeyboardSpeed.Slowest, RGBKeyboardBrightness.Low,
+                     new(new(255, 255, 255), false), new(new(255,255,255), false), new(new(255,255,255), false), new(new(255,255,255), false)) },
             }),
         };
     }

--- a/LenovoLegionToolkit.Lib/Settings/RGBKeyboardSettingsZoneConverter.cs
+++ b/LenovoLegionToolkit.Lib/Settings/RGBKeyboardSettingsZoneConverter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace LenovoLegionToolkit.Lib.Settings
+{
+    internal class RGBKeyboardSettingsZoneConverter : JsonConverter<RGBKeyboardZone?>
+    {
+        public override bool CanWrite => false;
+
+        public override RGBKeyboardZone? ReadJson(JsonReader reader, Type objectType, RGBKeyboardZone? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var jObject = serializer.Deserialize<JObject>(reader);
+
+            if (jObject == null)
+                return null;
+
+            bool jObjectIsRgbColor = jObject.Property("R") != null
+                                      && jObject.Property("G") != null
+                                      && jObject.Property("B") != null;
+
+            if (jObjectIsRgbColor)
+                return new(jObject.ToObject<RGBColor>(), false);
+            else
+                return jObject.ToObject<RGBKeyboardZone>();
+        }
+
+        public override void WriteJson(JsonWriter writer, RGBKeyboardZone? value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/LenovoLegionToolkit.Lib/Structs.cs
+++ b/LenovoLegionToolkit.Lib/Structs.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using LenovoLegionToolkit.Lib.Extensions;
+using LenovoLegionToolkit.Lib.Settings;
 using Newtonsoft.Json;
 using Octokit;
 
@@ -250,25 +251,46 @@ namespace LenovoLegionToolkit.Lib
         public static bool operator !=(RGBColor left, RGBColor right) => !left.Equals(right);
     }
 
+    public struct RGBKeyboardZone
+    {
+        public RGBColor Color { get; }
+        public bool SyncSystemAccentColor { get; }
+
+        [JsonConstructor]
+        public RGBKeyboardZone(RGBColor color, bool syncSystemAccentColor)
+        {
+            Color = color;
+            SyncSystemAccentColor = syncSystemAccentColor;
+        }
+    }
+
     public struct RGBKeyboardBacklightSettings
     {
         public RGBKeyboardEffect Effect { get; } = RGBKeyboardEffect.Static;
         public RBGKeyboardSpeed Speed { get; } = RBGKeyboardSpeed.Slowest;
         public RGBKeyboardBrightness Brightness { get; } = RGBKeyboardBrightness.Low;
-        public RGBColor Zone1 { get; } = new();
-        public RGBColor Zone2 { get; } = new();
-        public RGBColor Zone3 { get; } = new();
-        public RGBColor Zone4 { get; } = new();
+
+        [JsonConverter(typeof(RGBKeyboardSettingsZoneConverter))]
+        public RGBKeyboardZone Zone1 { get; }
+
+        [JsonConverter(typeof(RGBKeyboardSettingsZoneConverter))]
+        public RGBKeyboardZone Zone2 { get; }
+
+        [JsonConverter(typeof(RGBKeyboardSettingsZoneConverter))]
+        public RGBKeyboardZone Zone3 { get; }
+
+        [JsonConverter(typeof(RGBKeyboardSettingsZoneConverter))]
+        public RGBKeyboardZone Zone4 { get; }
 
         [JsonConstructor]
         public RGBKeyboardBacklightSettings(
             RGBKeyboardEffect effect,
             RBGKeyboardSpeed speed,
             RGBKeyboardBrightness brightness,
-            RGBColor zone1,
-            RGBColor zone2,
-            RGBColor zone3,
-            RGBColor zone4)
+            RGBKeyboardZone zone1,
+            RGBKeyboardZone zone2,
+            RGBKeyboardZone zone3,
+            RGBKeyboardZone zone4)
         {
             Effect = effect;
             Speed = speed;

--- a/LenovoLegionToolkit.Lib/Structs.cs
+++ b/LenovoLegionToolkit.Lib/Structs.cs
@@ -237,6 +237,17 @@ namespace LenovoLegionToolkit.Lib
             G = g;
             B = b;
         }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is RGBColor color && R == color.R && G == color.G && B == color.B;
+        }
+
+        public override int GetHashCode() => (R, G, B).GetHashCode();
+
+        public static bool operator ==(RGBColor left, RGBColor right) => left.Equals(right);
+
+        public static bool operator !=(RGBColor left, RGBColor right) => !left.Equals(right);
     }
 
     public struct RGBKeyboardBacklightSettings
@@ -402,6 +413,18 @@ namespace LenovoLegionToolkit.Lib
         {
             Width = width;
             Height = height;
+        }
+    }
+
+    public struct SystemThemeSettings
+    {
+        public bool IsDarkMode { get; }
+        public RGBColor AccentColor { get; }
+
+        public SystemThemeSettings(bool isDarkMode, RGBColor accentColor)
+        {
+            IsDarkMode = isDarkMode;
+            AccentColor = accentColor;
         }
     }
 }

--- a/LenovoLegionToolkit.Lib/System/SystemTheme.cs
+++ b/LenovoLegionToolkit.Lib/System/SystemTheme.cs
@@ -1,0 +1,52 @@
+﻿using LenovoLegionToolkit.Lib.Settings;
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LenovoLegionToolkit.Lib.System
+{
+    public static class SystemTheme
+    {
+        private const string RegistryHive = "HKEY_CURRENT_USER";
+
+        private const string PersonalizeRegistryPath = @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize";
+        private const string AppsUseLightThemeRegistryKey = "AppsUseLightTheme";
+
+        private const string DwmRegistryPath = @"Software\Microsoft\Windows\DWM";
+        private const string DwmColorizationColorRegistryKey = "ColorizationColor";
+
+        public static bool GetDarkMode()
+        {
+            var registryValue = Registry.Read(RegistryHive, PersonalizeRegistryPath, AppsUseLightThemeRegistryKey, -1);
+            if (registryValue == -1)
+                throw new InvalidOperationException($"Couldn't read the {AppsUseLightThemeRegistryKey} setting.");
+
+            return registryValue == 0;
+        }
+
+        public static RGBColor GetAccentColor()
+        {
+            var registryValue = Registry.Read(RegistryHive, DwmRegistryPath, DwmColorizationColorRegistryKey, -1);
+
+            if (registryValue == -1)
+                throw new InvalidOperationException($"Couldn't read the {DwmColorizationColorRegistryKey} setting.");
+
+            var registryValueBytes = BitConverter.GetBytes(registryValue);
+
+            return new(registryValueBytes[2], registryValueBytes[1], registryValueBytes[0]);
+        }
+
+        internal static IDisposable GetDarkModeListener(Action callback)
+        {
+            return Registry.Listen(RegistryHive, PersonalizeRegistryPath, AppsUseLightThemeRegistryKey, callback);
+        }
+
+        internal static IDisposable GetAccentColorListener(Action callback)
+        {
+            return Registry.Listen(RegistryHive, DwmRegistryPath, DwmColorizationColorRegistryKey, callback);
+        }
+    }
+}

--- a/LenovoLegionToolkit.WPF/Controls/ColorCardControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/ColorCardControl.cs
@@ -117,7 +117,7 @@ namespace LenovoLegionToolkit.WPF.Controls
             set => _cardHeaderControl.Subtitle = value;
         }
 
-        public event EventHandler? OnChanged;
+        public event EventHandler? OnChanged, OnChangedByUser;
 
         public ColorCardControl() => InitializeComponent();
 
@@ -193,6 +193,9 @@ namespace LenovoLegionToolkit.WPF.Controls
             {
                 OnChanged?.Invoke(this, EventArgs.Empty);
 
+                if (!_wasSetColorCalled)
+                    OnChangedByUser?.Invoke(this, EventArgs.Empty);
+
                 _raisedOnChanged = true;
             }
         }
@@ -209,6 +212,7 @@ namespace LenovoLegionToolkit.WPF.Controls
         private void ColorsPanel_MouseUp(object sender, MouseButtonEventArgs e)
         {
             OnChanged?.Invoke(this, EventArgs.Empty);
+            OnChangedByUser?.Invoke(this, EventArgs.Empty);
         }
 
         public void SetColor(RGBColor color)

--- a/LenovoLegionToolkit.WPF/Controls/ColorCardControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/ColorCardControl.cs
@@ -157,10 +157,12 @@ namespace LenovoLegionToolkit.WPF.Controls
             _colorsPanel.Children.Add(_rgbGrid);
 
             _cardExpander.Header = _cardHeaderControl;
-            _cardExpander.Content = _colorsPanel;
+            _cardExpander.Content = GetCardExpanderPanel();
 
             Content = _cardExpander;
         }
+
+        protected virtual StackPanel GetCardExpanderPanel() => _colorsPanel;
 
         //
         // These flags are used to prevent ColorTextBox_TextChanged from raising OnChanged

--- a/LenovoLegionToolkit.WPF/Controls/ColorCardControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/ColorCardControl.cs
@@ -162,6 +162,12 @@ namespace LenovoLegionToolkit.WPF.Controls
             Content = _cardExpander;
         }
 
+        //
+        // These flags are used to prevent ColorTextBox_TextChanged from raising OnChanged
+        // repeatedly when SetColor is called.
+        //
+        private bool _wasSetColorCalled = false, _raisedOnChanged = false;
+
         private void ColorTextBox_TextChanged(object sender, TextChangedEventArgs e)
         {
             var result = byte.TryParse(_redTextBox.Text, out var r);
@@ -178,8 +184,15 @@ namespace LenovoLegionToolkit.WPF.Controls
 
             _colorPicker.SelectedColor = Color.FromRgb(r, g, b);
 
+            if (_wasSetColorCalled && _raisedOnChanged)
+                return;
+
             if (Mouse.LeftButton == MouseButtonState.Released && Mouse.RightButton == MouseButtonState.Released)
+            {
                 OnChanged?.Invoke(this, EventArgs.Empty);
+
+                _raisedOnChanged = true;
+            }
         }
 
         private void ColorPicker_ColorChanged(object sender, RoutedEventArgs e)
@@ -198,6 +211,9 @@ namespace LenovoLegionToolkit.WPF.Controls
 
         public void SetColor(RGBColor color)
         {
+            _wasSetColorCalled = true;
+            _raisedOnChanged = false;
+
             var c = Color.FromRgb(color.R, color.G, color.B);
             _redTextBox.Text = color.R.ToString();
             _greenTextBox.Text = color.G.ToString();
@@ -205,6 +221,8 @@ namespace LenovoLegionToolkit.WPF.Controls
             _colorPicker.SelectedColor = c;
             _colorButton.Background = new SolidColorBrush(c);
             _colorButton.Visibility = Visibility.Visible;
+
+            _wasSetColorCalled = _raisedOnChanged = false;
         }
 
         public RGBColor GetColor()

--- a/LenovoLegionToolkit.WPF/Controls/ColorCardSystemAwareControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/ColorCardSystemAwareControl.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using ColorPicker;
+using LenovoLegionToolkit.Lib;
+using LenovoLegionToolkit.Lib.System;
+using LenovoLegionToolkit.Lib.Listeners;
+using LenovoLegionToolkit.Lib.Settings;
+using LenovoLegionToolkit.WPF.Utils;
+using Wpf.Ui.Common;
+using Wpf.Ui.Controls;
+using Button = System.Windows.Controls.Button;
+using Color = System.Windows.Media.Color;
+
+namespace LenovoLegionToolkit.WPF.Controls
+{
+    public class ColorCardSystemAwareControl : ColorCardControl
+    {
+        private readonly SystemThemeListener _listener = IoCContainer.Resolve<SystemThemeListener>();
+
+        private StackPanel? _colorsPanel;
+
+        private readonly CheckBox _syncSystemAccentColorCheckBox = new()
+        {
+            Margin = new(0, 0, 0, 8),
+
+            Content = new TextBlock
+            {
+                Text = "Match the system accent color",
+                TextWrapping = TextWrapping.Wrap,
+            }
+        };
+
+        public event EventHandler? OnSyncSystemAccentColorChanged, OnSyncSystemAccentColorChangedByUser;
+
+        public ColorCardSystemAwareControl()
+        {
+            _listener.Changed += Listener_Changed;
+        }
+
+        protected override StackPanel GetCardExpanderPanel()
+        {
+            _colorsPanel = base.GetCardExpanderPanel();
+
+            var stackPanel = new StackPanel();
+
+            stackPanel.Children.Add(_syncSystemAccentColorCheckBox);
+            stackPanel.Children.Add(_colorsPanel);
+
+            _syncSystemAccentColorCheckBox.Checked += SyncSystemAccentColorCheckBox_Changed;
+            _syncSystemAccentColorCheckBox.Unchecked += SyncSystemAccentColorCheckBox_Changed;
+
+            return stackPanel;
+        }
+
+        private bool _wasSetSyncSystemAccentColorCalled = false;
+
+        private void SyncSystemAccentColorCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (GetSyncSystemAccentColor())
+                SetColor(SystemTheme.GetAccentColor());
+
+            _colorsPanel!.IsEnabled = !GetSyncSystemAccentColor();
+
+            OnSyncSystemAccentColorChanged?.Invoke(this, EventArgs.Empty);
+
+            if (!_wasSetSyncSystemAccentColorCalled)
+                OnSyncSystemAccentColorChangedByUser?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void Listener_Changed(object? sender, SystemThemeSettings e) => Dispatcher.Invoke(() =>
+        {
+            if (GetSyncSystemAccentColor())
+                SetColor(e.AccentColor);
+        });
+
+        public bool GetSyncSystemAccentColor() => _syncSystemAccentColorCheckBox.IsChecked ?? false;
+
+        public void SetSyncSystemAccentColor(bool state)
+        {
+            _wasSetSyncSystemAccentColorCalled = true;
+            _syncSystemAccentColorCheckBox.IsChecked = state;
+            _wasSetSyncSystemAccentColorCalled = false;
+        }
+    }
+}

--- a/LenovoLegionToolkit.WPF/Controls/KeyboardBacklight/RGBKeyboardBacklightControl.xaml
+++ b/LenovoLegionToolkit.WPF/Controls/KeyboardBacklight/RGBKeyboardBacklightControl.xaml
@@ -103,7 +103,7 @@
             Margin="0,0,8,0"
             OnChanged="CardControl_OnChanged" />
 
-        <controls:ColorCardControl
+        <controls:ColorCardSystemAwareControl
             x:Name="_zone1Control"
             Title="Zone 1"
             Grid.Row="5"
@@ -111,7 +111,8 @@
             Margin="0,0,8,8"
             VerticalAlignment="Top"
             Icon="Color24"
-            OnChanged="CardControl_OnChanged">
+            OnChangedByUser="CardControl_OnChanged"
+            OnSyncSystemAccentColorChangedByUser="CardControl_OnChanged">
             <controls:ColorCardControl.ContextMenu>
                 <ContextMenu>
                     <wpfui:MenuItem
@@ -120,9 +121,9 @@
                         SymbolIcon="ArrowsBidirectional24" />
                 </ContextMenu>
             </controls:ColorCardControl.ContextMenu>
-        </controls:ColorCardControl>
+        </controls:ColorCardSystemAwareControl>
 
-        <controls:ColorCardControl
+        <controls:ColorCardSystemAwareControl
             x:Name="_zone2Control"
             Title="Zone 2"
             Grid.Row="5"
@@ -130,7 +131,8 @@
             Margin="0,0,8,8"
             VerticalAlignment="Top"
             Icon="Color24"
-            OnChanged="CardControl_OnChanged">
+            OnChangedByUser="CardControl_OnChanged"
+            OnSyncSystemAccentColorChangedByUser="CardControl_OnChanged">
             <controls:ColorCardControl.ContextMenu>
                 <ContextMenu>
                     <wpfui:MenuItem
@@ -139,9 +141,9 @@
                         SymbolIcon="ArrowsBidirectional24" />
                 </ContextMenu>
             </controls:ColorCardControl.ContextMenu>
-        </controls:ColorCardControl>
+        </controls:ColorCardSystemAwareControl>
 
-        <controls:ColorCardControl
+        <controls:ColorCardSystemAwareControl
             x:Name="_zone3Control"
             Title="Zone 3"
             Grid.Row="5"
@@ -149,7 +151,8 @@
             Margin="0,0,8,8"
             VerticalAlignment="Top"
             Icon="Color24"
-            OnChanged="CardControl_OnChanged">
+            OnChangedByUser="CardControl_OnChanged"
+            OnSyncSystemAccentColorChangedByUser="CardControl_OnChanged">
             <controls:ColorCardControl.ContextMenu>
                 <ContextMenu>
                     <wpfui:MenuItem
@@ -158,9 +161,9 @@
                         SymbolIcon="ArrowsBidirectional24" />
                 </ContextMenu>
             </controls:ColorCardControl.ContextMenu>
-        </controls:ColorCardControl>
+        </controls:ColorCardSystemAwareControl>
 
-        <controls:ColorCardControl
+        <controls:ColorCardSystemAwareControl
             x:Name="_zone4Control"
             Title="Zone 4"
             Grid.Row="5"
@@ -168,7 +171,8 @@
             Margin="0,0,8,8"
             VerticalAlignment="Top"
             Icon="Color24"
-            OnChanged="CardControl_OnChanged">
+            OnChangedByUser="CardControl_OnChanged"
+            OnSyncSystemAccentColorChangedByUser="CardControl_OnChanged">
             <controls:ColorCardControl.ContextMenu>
                 <ContextMenu>
                     <wpfui:MenuItem
@@ -177,7 +181,7 @@
                         SymbolIcon="ArrowsBidirectional24" />
                 </ContextMenu>
             </controls:ColorCardControl.ContextMenu>
-        </controls:ColorCardControl>
+        </controls:ColorCardSystemAwareControl>
 
     </Grid>
 

--- a/LenovoLegionToolkit.WPF/Controls/KeyboardBacklight/RGBKeyboardBacklightControl.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Controls/KeyboardBacklight/RGBKeyboardBacklightControl.xaml.cs
@@ -16,7 +16,7 @@ namespace LenovoLegionToolkit.WPF.Controls.KeyboardBacklight
     {
         private Button[] PresetButtons => new[] { _offPresetButton, _preset1Button, _preset2Button, _preset3Button };
 
-        private ColorCardControl[] Zones => new[] { _zone1Control, _zone2Control, _zone3Control, _zone4Control };
+        private ColorCardSystemAwareControl[] Zones => new[] { _zone1Control, _zone2Control, _zone3Control, _zone4Control };
 
         private readonly RGBKeyboardBacklightController _controller = IoCContainer.Resolve<RGBKeyboardBacklightController>();
         private readonly RGBKeyboardBacklightListener _listener = IoCContainer.Resolve<RGBKeyboardBacklightListener>();
@@ -65,11 +65,14 @@ namespace LenovoLegionToolkit.WPF.Controls.KeyboardBacklight
         }
         private async void SynchroniseZonesMenuItem_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is not MenuItem menuItem || menuItem.Parent is not ContextMenu menu || menu.PlacementTarget is not ColorCardControl control)
+            if (sender is not MenuItem menuItem || menuItem.Parent is not ContextMenu menu || menu.PlacementTarget is not ColorCardSystemAwareControl control)
                 return;
 
             foreach (var zone in Zones)
+            {
                 zone.SetColor(control.GetColor());
+                zone.SetSyncSystemAccentColor(control.GetSyncSystemAccentColor());
+            }
 
             await SaveState();
             await RefreshAsync();
@@ -162,10 +165,21 @@ namespace LenovoLegionToolkit.WPF.Controls.KeyboardBacklight
 
             if (zonesEnabled)
             {
-                _zone1Control.SetColor(preset.Zone1);
-                _zone2Control.SetColor(preset.Zone2);
-                _zone3Control.SetColor(preset.Zone3);
-                _zone4Control.SetColor(preset.Zone4);
+                if (!preset.Zone1.SyncSystemAccentColor)
+                    _zone1Control.SetColor(preset.Zone1.Color);
+                _zone1Control.SetSyncSystemAccentColor(preset.Zone1.SyncSystemAccentColor);
+
+                if (!preset.Zone2.SyncSystemAccentColor)
+                    _zone2Control.SetColor(preset.Zone2.Color);
+                _zone2Control.SetSyncSystemAccentColor(preset.Zone2.SyncSystemAccentColor);
+
+                if (!preset.Zone3.SyncSystemAccentColor)
+                    _zone3Control.SetColor(preset.Zone3.Color);
+                _zone3Control.SetSyncSystemAccentColor(preset.Zone3.SyncSystemAccentColor);
+
+                if (!preset.Zone4.SyncSystemAccentColor)
+                    _zone4Control.SetColor(preset.Zone4.Color);
+                _zone4Control.SetSyncSystemAccentColor(preset.Zone4.SyncSystemAccentColor);
             }
             else
             {
@@ -200,10 +214,10 @@ namespace LenovoLegionToolkit.WPF.Controls.KeyboardBacklight
             presets[selectedPreset] = new(_effectControl.SelectedItem,
                                           _speedControl.SelectedItem,
                                           _brightnessControl.SelectedItem,
-                                          _zone1Control.GetColor(),
-                                          _zone2Control.GetColor(),
-                                          _zone3Control.GetColor(),
-                                          _zone4Control.GetColor());
+                                          new(_zone1Control.GetColor(), _zone1Control.GetSyncSystemAccentColor()),
+                                          new(_zone2Control.GetColor(), _zone2Control.GetSyncSystemAccentColor()),
+                                          new(_zone3Control.GetColor(), _zone3Control.GetSyncSystemAccentColor()),
+                                          new(_zone4Control.GetColor(), _zone4Control.GetSyncSystemAccentColor()));
 
             await _controller.SetStateAsync(new(selectedPreset, presets));
         }

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml
@@ -33,12 +33,13 @@
                 Visibility="Hidden" />
         </wpfui:CardControl>
 
-        <controls:ColorCardControl
+        <controls:ColorCardSystemAwareControl
             x:Name="_accentColor"
             Title="Accent color"
             Margin="0,0,0,24"
             Icon="Color24"
             OnChanged="AccentColorControl_OnChanged"
+            OnSyncSystemAccentColorChanged="AccentColorControl_OnSyncSystemAccentColorChanged"
             Subtitle="Change the accent color of the app." />
 
         <wpfui:CardControl Margin="0,0,0,8">

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
@@ -45,7 +45,8 @@ namespace LenovoLegionToolkit.WPF.Pages
             var loadingTask = Task.Delay(250);
 
             _themeComboBox.SetItems(Enum.GetValues<Theme>(), _settings.Store.Theme);
-            _accentColor.SetColor(_settings.Store.AccentColor ?? _themeManager.DefaultAccentColor);
+            _accentColor.SetColor(_themeManager.AccentColor);
+            _accentColor.SetSyncSystemAccentColor(_settings.Store.SyncSystemAccentColor);
             _autorunToggle.IsChecked = Autorun.IsEnabled;
             _minimizeOnCloseToggle.IsChecked = _settings.Store.MinimizeOnClose;
 
@@ -94,6 +95,17 @@ namespace LenovoLegionToolkit.WPF.Pages
                 return;
 
             _settings.Store.AccentColor = _accentColor.GetColor();
+            _settings.SynchronizeStore();
+
+            _themeManager.Apply();
+        }
+
+        private void AccentColorControl_OnSyncSystemAccentColorChanged(object sender, EventArgs e)
+        {
+            if (_isRefreshing)
+                return;
+
+            _settings.Store.SyncSystemAccentColor = _accentColor.GetSyncSystemAccentColor();
             _settings.SynchronizeStore();
 
             _themeManager.Apply();

--- a/LenovoLegionToolkit.WPF/Utils/ThemeManager.cs
+++ b/LenovoLegionToolkit.WPF/Utils/ThemeManager.cs
@@ -34,12 +34,15 @@ namespace LenovoLegionToolkit.WPF.Utils
             }
         }
 
+        public RGBColor AccentColor { get; private set; }
+
         public event EventHandler? ThemeApplied;
 
         public ThemeManager(ApplicationSettings settings)
         {
             _settings = settings;
             _listener.Changed += (object? s, SystemThemeSettings e) => Application.Current.Dispatcher.Invoke(Apply);
+            AccentColor = DefaultAccentColor;
         }
 
         public void Apply()
@@ -58,8 +61,10 @@ namespace LenovoLegionToolkit.WPF.Utils
 
         private void SetColor()
         {
-            var accentColorRgb = _settings.Store.AccentColor ?? DefaultAccentColor;
-            var accentColor = Color.FromRgb(accentColorRgb.R, accentColorRgb.G, accentColorRgb.B);
+            AccentColor = _settings.Store.SyncSystemAccentColor ? SystemTheme.GetAccentColor()
+                                                                : _settings.Store.AccentColor ?? DefaultAccentColor;
+
+            var accentColor = Color.FromRgb(AccentColor.R, AccentColor.G, AccentColor.B);
             Wpf.Ui.Appearance.Accent.Apply(systemAccent: accentColor,
                 primaryAccent: accentColor,
                 secondaryAccent: accentColor,


### PR DESCRIPTION
This adds the option to match both the app accent color and/or keyboard lightning zones to the system color.