### PR TITLE
Switch to Balance mode before switching to Performance

### DIFF
--- a/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
+++ b/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
@@ -39,6 +39,10 @@ namespace LenovoLegionToolkit.Lib.Features
 
             var currentState = await GetStateAsync().ConfigureAwait(false);
 
+            // Peformance mode relies on some properties set by Balance (like dGPU temp limit).
+            if (currentState == PowerModeState.Quiet && state == PowerModeState.Performance)
+                await base.SetStateAsync(PowerModeState.Balance).ConfigureAwait(false);
+
             await base.SetStateAsync(state).ConfigureAwait(false);
 
             await _aiModeController.StartStopAsync(state).ConfigureAwait(false);

--- a/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
+++ b/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
@@ -39,8 +39,9 @@ namespace LenovoLegionToolkit.Lib.Features
 
             var currentState = await GetStateAsync().ConfigureAwait(false);
 
-            // Peformance mode relies on some properties set by Balance (like dGPU temp limit).
-            if (currentState == PowerModeState.Quiet && state == PowerModeState.Performance)
+            // Workaround: Peformance mode doesn't update the dGPU temp limit (and possibly other properties) on some Gen 7 devices.
+            var mi = await Compatibility.GetMachineInformationAsync().ConfigureAwait(false);
+            if (mi.Properties.HasPerformanceModeSwitchingBug && currentState == PowerModeState.Quiet && state == PowerModeState.Performance)
                 await base.SetStateAsync(PowerModeState.Balance).ConfigureAwait(false);
 
             await base.SetStateAsync(state).ConfigureAwait(false);

--- a/LenovoLegionToolkit.Lib/Structs.cs
+++ b/LenovoLegionToolkit.Lib/Structs.cs
@@ -152,6 +152,7 @@ namespace LenovoLegionToolkit.Lib
             public bool SupportsACDetection { get; init; }
             public bool SupportsExtendedHybridMode { get; init; }
             public bool SupportsIntelligentSubMode { get; init; }
+            public bool HasPerformanceModeSwitchingBug { get; init; }
         }
 
         public string Vendor { get; init; }

--- a/LenovoLegionToolkit.Lib/Utils/Compatibility.cs
+++ b/LenovoLegionToolkit.Lib/Utils/Compatibility.cs
@@ -67,7 +67,8 @@ namespace LenovoLegionToolkit.Lib.Utils
                         SupportsGodMode = GetSupportsGodMode(biosVersion),
                         SupportsACDetection = await GetSupportsACDetection().ConfigureAwait(false),
                         SupportsExtendedHybridMode = await GetSupportsExtendedHybridModeAsync().ConfigureAwait(false),
-                        SupportsIntelligentSubMode = await GetSupportsIntelligentSubModeAsync().ConfigureAwait(false)
+                        SupportsIntelligentSubMode = await GetSupportsIntelligentSubModeAsync().ConfigureAwait(false),
+                        HasPerformanceModeSwitchingBug = GetHasPerformanceModeSwitchingBug(biosVersion)
                     }
                 };
 
@@ -210,6 +211,23 @@ namespace LenovoLegionToolkit.Lib.Utils
                                 $"SELECT * FROM Win32_BIOS",
                                 pdc => (string)pdc["Name"].Value).ConfigureAwait(false);
             return result.First();
+        }
+
+        private static bool GetHasPerformanceModeSwitchingBug(string biosVersion)
+        {
+            (string, int?)[] affectedBiosList =
+            {
+                ("J2CN", null)
+            };
+
+            foreach (var (biosPrefix, maximumVersion) in affectedBiosList)
+            {
+                if (biosVersion.StartsWith(biosPrefix)
+                    && (maximumVersion == null || int.TryParse(biosVersion.Replace(biosPrefix, null).Replace("WW", null), out var rev) && rev <= maximumVersion))
+                    return true;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
Enabling Performance made in the app doesn't update the dGPU temp limit as this is previously set by the Balance mode when pressing FN + R.