### PR TITLE
The default Quick Action for deactivating the GPU should now be local…

### DIFF
--- a/LenovoLegionToolkit.Lib.Automation/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.Lib.Automation/Resources/Resource.Designer.cs
@@ -97,6 +97,15 @@ namespace LenovoLegionToolkit.Lib.Automation.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deactivate GPU.
+        /// </summary>
+        public static string DeactivateGpuQuickAction_Title {
+            get {
+                return ResourceManager.GetString("DeactivateGpuQuickAction_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} second.
         /// </summary>
         public static string Delay_Second {

--- a/LenovoLegionToolkit.Lib.Automation/Resources/Resource.resx
+++ b/LenovoLegionToolkit.Lib.Automation/Resources/Resource.resx
@@ -178,9 +178,13 @@
     <value>When game is running</value>
   </data>
   <data name="UserInactivityAutomationPipelineTrigger_DisplayName_Zero" xml:space="preserve">
-	  <value>When user becomes active</value>
+    <value>When user becomes active</value>
   </data>
   <data name="UserInactivityAutomationPipelineTrigger_DisplayName" xml:space="preserve">
-	  <value>When user becomes inactive</value>
+    <value>When user becomes inactive</value>
+  </data>
+  <data name="DeactivateGpuQuickAction_Title" xml:space="preserve">
+    <value>Deactivate GPU</value>
+    <comment>The display name of the default Quick Action that is presented to the user upon first installation.</comment>
   </data>
 </root>

--- a/LenovoLegionToolkit.Lib.Automation/Utils/AutomationSettings.cs
+++ b/LenovoLegionToolkit.Lib.Automation/Utils/AutomationSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using LenovoLegionToolkit.Lib.Automation.Pipeline;
 using LenovoLegionToolkit.Lib.Automation.Pipeline.Triggers;
+using LenovoLegionToolkit.Lib.Automation.Resources;
 using LenovoLegionToolkit.Lib.Automation.Steps;
 using LenovoLegionToolkit.Lib.Settings;
 
@@ -31,7 +32,7 @@ public class AutomationSettings : AbstractSettings<AutomationSettings.Automation
             },
             new AutomationPipeline
             {
-                Name = "Deactivate GPU",
+                Name = Resource.DeactivateGpuQuickAction_Title,
                 Steps = { new DeactivateGPUAutomationStep(DeactivateGPUAutomationStepState.KillApps) },
             },
         },


### PR DESCRIPTION
The default Quick Action that is named "Deactivate GPU" should now be localizable. However, I have realized that this will affect only new users or users that reinstall. Furthermore, if they switch the language the localization will still be innacurate.