### PR TITLE
Warranty status will now be properly displayed if the warranty expires while the app is open

### DIFF
--- a/LenovoLegionToolkit.Lib/Utils/WarrantyChecker.cs
+++ b/LenovoLegionToolkit.Lib/Utils/WarrantyChecker.cs
@@ -39,20 +39,20 @@ public class WarrantyChecker
     private WarrantyInfo LocalWarrantyInfo(WarrantyInfo currentInfo)
     {
         var updatedStatus = GetWarrantyStatus(currentInfo.End);
-        if (updatedStatus != currentInfo.Status)
-        {
-            var locallyUpdatedWarrantyInfo = new WarrantyInfo 
-            { 
-                Start = currentInfo.Start,
-                End = currentInfo.End,
-                Link = currentInfo.Link,
-                Status = updatedStatus 
-            };
-            _settings.Store.WarrantyInfo = locallyUpdatedWarrantyInfo;
-            _settings.SynchronizeStore();
-            return locallyUpdatedWarrantyInfo;
-        }
-        return currentInfo;
+
+        if (updatedStatus == currentInfo.Status)
+            return currentInfo;
+
+        var locallyUpdatedWarrantyInfo = new WarrantyInfo 
+        { 
+            Start = currentInfo.Start,
+            End = currentInfo.End,
+            Link = currentInfo.Link,
+            Status = updatedStatus 
+        };
+        _settings.Store.WarrantyInfo = locallyUpdatedWarrantyInfo;
+        _settings.SynchronizeStore();
+        return locallyUpdatedWarrantyInfo;
     }
 
     private string GetWarrantyStatus(DateTime? endDate)

--- a/LenovoLegionToolkit.Lib/Utils/WarrantyChecker.cs
+++ b/LenovoLegionToolkit.Lib/Utils/WarrantyChecker.cs
@@ -20,7 +20,10 @@ public class WarrantyChecker
     public async Task<WarrantyInfo?> GetWarrantyInfo(MachineInformation machineInformation, bool forceRefresh = false, CancellationToken token = default)
     {
         if (!forceRefresh && _settings.Store.WarrantyInfo.HasValue)
-            return _settings.Store.WarrantyInfo.Value;
+        {
+            var currentInfo = _settings.Store.WarrantyInfo.Value;
+            return LocalWarrantyInfo(currentInfo);
+        }
 
         using var httpClient = new HttpClient();
 
@@ -31,6 +34,34 @@ public class WarrantyChecker
         _settings.SynchronizeStore();
 
         return warrantyInfo;
+    }
+
+    private WarrantyInfo LocalWarrantyInfo(WarrantyInfo currentInfo)
+    {
+        var updatedStatus = GetWarrantyStatus(currentInfo.End);
+        if (updatedStatus != currentInfo.Status)
+        {
+            var locallyUpdatedWarrantyInfo = new WarrantyInfo 
+            { 
+                Start = currentInfo.Start,
+                End = currentInfo.End,
+                Link = currentInfo.Link,
+                Status = updatedStatus 
+            };
+            _settings.Store.WarrantyInfo = locallyUpdatedWarrantyInfo;
+            _settings.SynchronizeStore();
+            return locallyUpdatedWarrantyInfo;
+        }
+        return currentInfo;
+    }
+
+    private string GetWarrantyStatus(DateTime? endDate)
+    {
+        var status = "In Warranty";
+        var now = DateTime.Now;
+        if (now > endDate)
+            status = "Out of Warranty";
+        return status;
     }
 
     private async Task<WarrantyInfo?> GetStandardWarrantyInfo(HttpClient httpClient, MachineInformation machineInformation,
@@ -86,10 +117,7 @@ public class WarrantyChecker
         DateTime? startDate = startDateString is null ? null : DateTime.Parse(startDateString);
         DateTime? endDate = endDateString is null ? null : DateTime.Parse(endDateString);
 
-        var status = "In Warranty";
-        var now = DateTime.Now;
-        if (now > endDate)
-            status = "Out of Warranty";
+        var status = GetWarrantyStatus(endDate);
 
         var link = new Uri($"https://newsupport.lenovo.com.cn/deviceGuarantee.html?fromsource=deviceGuarantee&selname={machineInformation.SerialNumber}");
 

--- a/LenovoLegionToolkit.Lib/Utils/WarrantyChecker.cs
+++ b/LenovoLegionToolkit.Lib/Utils/WarrantyChecker.cs
@@ -50,8 +50,10 @@ public class WarrantyChecker
             Link = currentInfo.Link,
             Status = updatedStatus 
         };
+
         _settings.Store.WarrantyInfo = locallyUpdatedWarrantyInfo;
         _settings.SynchronizeStore();
+
         return locallyUpdatedWarrantyInfo;
     }
 


### PR DESCRIPTION
See [issue 524](https://github.com/BartoszCichecki/LenovoLegionToolkit/issues/524) and my comment there.