### PR TITLE
Show error messages when failing to set / reset custom boot logo

### DIFF
--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -1001,6 +1001,87 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Custom logo could not be set: {0}.
+        /// </summary>
+        public static string BootLogoWindow_SetCustomFailed {
+            get {
+                return ResourceManager.GetString("BootLogoWindow_SetCustomFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Custom boot logo set..
+        /// </summary>
+        public static string BootLogoWindow_SetCustomSuccess {
+            get {
+                return ResourceManager.GetString("BootLogoWindow_SetCustomSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default logo could not be set: {0}.
+        /// </summary>
+        public static string BootLogoWindow_SetDefaultFailed {
+            get {
+                return ResourceManager.GetString("BootLogoWindow_SetDefaultFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default boot logo set..
+        /// </summary>
+        public static string BootLogoWindow_SetDefaultSuccess {
+            get {
+                return ResourceManager.GetString("BootLogoWindow_SetDefaultSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot mount EFI partition..
+        /// </summary>
+        public static string BootLogoWindow_SetError_Cannot_Mount_EFI_Partition {
+            get {
+                return ResourceManager.GetString("BootLogoWindow_SetError_Cannot_Mount_EFI_Partition", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot set UEFI privilege..
+        /// </summary>
+        public static string BootLogoWindow_SetError_Cannot_Set_UEFI_Privilege {
+            get {
+                return ResourceManager.GetString("BootLogoWindow_SetError_Cannot_Set_UEFI_Privilege", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid image format..
+        /// </summary>
+        public static string BootLogoWindow_SetError_Invalid_Image_format {
+            get {
+                return ResourceManager.GetString("BootLogoWindow_SetError_Invalid_Image_format", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid image size..
+        /// </summary>
+        public static string BootLogoWindow_SetError_Invalid_Image_Size {
+            get {
+                return ResourceManager.GetString("BootLogoWindow_SetError_Invalid_Image_Size", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not enough free space on EFI partition..
+        /// </summary>
+        public static string BootLogoWindow_SetError_Not_Enough_Free_Space_On_EFI_Partition {
+            get {
+                return ResourceManager.GetString("BootLogoWindow_SetError_Not_Enough_Free_Space_On_EFI_Partition", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Status.
         /// </summary>
         public static string BootLogoWindow_Status {

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -1948,19 +1948,46 @@ Requires restart.</value>
     <value>Off</value>
   </data>
   <data name="BootLogoWindow_Description" xml:space="preserve">
-	  <value>Custom boot logo must be exactly {0} pixels large.
+    <value>Custom boot logo must be exactly {0} pixels large.
 Supported formats are: {1}.</value>
   </data>
   <data name="BatteryNightChargeModeControl_Title" xml:space="preserve">
-	  <value>Overnight Battery Charging</value>
+    <value>Overnight Battery Charging</value>
   </data>
   <data name="BatteryNightChargeModeControl_Message" xml:space="preserve">
-	  <value>When enabled, this device will charge to 80% when plugged in overnight and finish charging to 100% by the time you use this device in the morning.</value>
+    <value>When enabled, this device will charge to 80% when plugged in overnight and finish charging to 100% by the time you use this device in the morning.</value>
   </data>
   <data name="BatteryNightChargeAutomationStepControl_Title" xml:space="preserve">
-	  <value>Overnight Battery Charging</value>
+    <value>Overnight Battery Charging</value>
   </data>
   <data name="BatteryNightChargeAutomationStepControl_Message" xml:space="preserve">
-	  <value>When enabled, this device will charge to 80% when plugged in overnight and finish charging to 100% by the time you use this device in the morning.</value>
+    <value>When enabled, this device will charge to 80% when plugged in overnight and finish charging to 100% by the time you use this device in the morning.</value>
+  </data>
+  <data name="BootLogoWindow_SetError_Invalid_Image_Size" xml:space="preserve">
+    <value>Invalid image size.</value>
+  </data>
+  <data name="BootLogoWindow_SetError_Invalid_Image_format" xml:space="preserve">
+    <value>Invalid image format.</value>
+  </data>
+  <data name="BootLogoWindow_SetError_Cannot_Mount_EFI_Partition" xml:space="preserve">
+    <value>Cannot mount EFI partition.</value>
+  </data>
+  <data name="BootLogoWindow_SetError_Cannot_Set_UEFI_Privilege" xml:space="preserve">
+    <value>Cannot set UEFI privilege.</value>
+  </data>
+  <data name="BootLogoWindow_SetError_Not_Enough_Free_Space_On_EFI_Partition" xml:space="preserve">
+    <value>Not enough free space on EFI partition.</value>
+  </data>
+  <data name="BootLogoWindow_SetCustomFailed" xml:space="preserve">
+    <value>Custom logo could not be set: {0}</value>
+  </data>
+  <data name="BootLogoWindow_SetDefaultFailed" xml:space="preserve">
+    <value>Default logo could not be set: {0}</value>
+  </data>
+  <data name="BootLogoWindow_SetDefaultSuccess" xml:space="preserve">
+    <value>Default boot logo set.</value>
+  </data>
+  <data name="BootLogoWindow_SetCustomSuccess" xml:space="preserve">
+    <value>Custom boot logo set.</value>
   </data>
 </root>

--- a/LenovoLegionToolkit.WPF/Windows/Settings/BootLogoWindow.xaml
+++ b/LenovoLegionToolkit.WPF/Windows/Settings/BootLogoWindow.xaml
@@ -90,6 +90,7 @@
                 Margin="0,24,0,0"
                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                 TextWrapping="Wrap" />
+
             <TextBlock
                 x:Name="_resultTextBlock"
                 Grid.Row="1"
@@ -101,10 +102,10 @@
                         <Style  TargetType="TextBlock">
                             <Setter Property="Foreground" Value="Red" />
                             <Style.Triggers>
-                                <Trigger Property="Text" Value="Custom boot logo set.">
+                                <Trigger Property="Text" Value="{x:Static resources:Resource.BootLogoWindow_SetCustomSuccess}">
                                     <Setter Property="Foreground" Value="Green" />
                                 </Trigger>
-                                <Trigger Property="Text" Value="Default boot logo set.">
+                                <Trigger Property="Text" Value="{x:Static resources:Resource.BootLogoWindow_SetDefaultSuccess}">
                                     <Setter Property="Foreground" Value="Green" />
                                 </Trigger>
                             </Style.Triggers>

--- a/LenovoLegionToolkit.WPF/Windows/Settings/BootLogoWindow.xaml
+++ b/LenovoLegionToolkit.WPF/Windows/Settings/BootLogoWindow.xaml
@@ -90,6 +90,27 @@
                 Margin="0,24,0,0"
                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                 TextWrapping="Wrap" />
+            <TextBlock
+                x:Name="_resultTextBlock"
+                Grid.Row="1"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Margin="0,82,0,0"
+                TextWrapping="Wrap">
+                <TextBlock.Style>
+                        <Style  TargetType="TextBlock">
+                            <Setter Property="Foreground" Value="Red" />
+                            <Style.Triggers>
+                                <Trigger Property="Text" Value="Custom boot logo set.">
+                                    <Setter Property="Foreground" Value="Green" />
+                                </Trigger>
+                                <Trigger Property="Text" Value="Default boot logo set.">
+                                    <Setter Property="Foreground" Value="Green" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+            </TextBlock>
         </Grid>
 
         <Grid Grid.Row="2" Margin="12">

--- a/LenovoLegionToolkit.WPF/Windows/Settings/BootLogoWindow.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Settings/BootLogoWindow.xaml.cs
@@ -34,6 +34,24 @@ public partial class BootLogoWindow
         _revertToDefaultButton.Visibility = enabled ? Visibility.Visible : Visibility.Collapsed;
     }
 
+    private string MapExceptionTranslation(string exMessage)
+    {
+        switch (exMessage)
+        {
+            case "Cannot set UEFI privilege.":
+                return Resource.BootLogoWindow_SetError_Cannot_Set_UEFI_Privilege;
+            case "Cannot mount EFI partition.":
+                return Resource.BootLogoWindow_SetError_Cannot_Mount_EFI_Partition;
+            case "Not enough free space on EFI partition.":
+                return Resource.BootLogoWindow_SetError_Not_Enough_Free_Space_On_EFI_Partition;
+            case "Invalid image size.":
+                return Resource.BootLogoWindow_SetError_Invalid_Image_Size;
+            case "Invalid image format.":
+                return Resource.BootLogoWindow_SetError_Invalid_Image_format;
+            default: return exMessage;
+        }
+    }
+
     private async void RevertToDefaultButton_Click(object sender, RoutedEventArgs e)
     {
         try
@@ -41,14 +59,14 @@ public partial class BootLogoWindow
             _revertToDefaultButton.IsEnabled = false;
 
             await BootLogo.DisableAsync();
-            _resultTextBlock.Text = "Default boot logo set.";
+            _resultTextBlock.Text = Resource.BootLogoWindow_SetDefaultSuccess;
             Refresh();
         }
         catch (Exception ex)
         {
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace($"Default logo could not be set.", ex);
-            _resultTextBlock.Text = "Default logo could not be set: " + ex.Message;
+            _resultTextBlock.Text = string.Format(Resource.BootLogoWindow_SetDefaultFailed, MapExceptionTranslation(ex.Message));
         }
         finally
         {
@@ -79,14 +97,14 @@ public partial class BootLogoWindow
             var file = ofd.FileName;
 
             await BootLogo.EnableAsync(file);
-            _resultTextBlock.Text = "Custom boot logo set.";
+            _resultTextBlock.Text = Resource.BootLogoWindow_SetCustomSuccess;
             Refresh();
         }
         catch (Exception ex)
         {
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace($"Custom logo could not be set.", ex);
-            _resultTextBlock.Text = "Custom logo could not be set: " + ex.Message;
+            _resultTextBlock.Text = string.Format(Resource.BootLogoWindow_SetCustomFailed, MapExceptionTranslation(ex.Message));
         }
         finally
         {

--- a/LenovoLegionToolkit.WPF/Windows/Settings/BootLogoWindow.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Settings/BootLogoWindow.xaml.cs
@@ -41,12 +41,14 @@ public partial class BootLogoWindow
             _revertToDefaultButton.IsEnabled = false;
 
             await BootLogo.DisableAsync();
+            _resultTextBlock.Text = "Default boot logo set.";
             Refresh();
         }
         catch (Exception ex)
         {
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace($"Default logo could not be set.", ex);
+            _resultTextBlock.Text = "Default logo could not be set: " + ex.Message;
         }
         finally
         {
@@ -77,12 +79,14 @@ public partial class BootLogoWindow
             var file = ofd.FileName;
 
             await BootLogo.EnableAsync(file);
+            _resultTextBlock.Text = "Custom boot logo set.";
             Refresh();
         }
         catch (Exception ex)
         {
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace($"Custom logo could not be set.", ex);
+            _resultTextBlock.Text = "Custom logo could not be set: " + ex.Message;
         }
         finally
         {


### PR DESCRIPTION
<!---
Important!

Please make yourself familiar with Contribution section in the README and CONTRIBUTING.md file to make sure that your pull request is compliant.
-->

Link: #1106 

I added a new TextBlock under `_descriptionTextBlock` to hold the messages.

```xaml
<TextBlock
    x:Name="_resultTextBlock"
    Grid.Row="1"
    Grid.Column="0"
    Grid.ColumnSpan="2"
    Margin="0,82,0,0"
    TextWrapping="Wrap">
    <TextBlock.Style>
            <Style  TargetType="TextBlock">
                <Setter Property="Foreground" Value="Red" />
                <Style.Triggers>
                    <Trigger Property="Text" Value="{x:Static resources:Resource.BootLogoWindow_SetCustomSuccess}">
                        <Setter Property="Foreground" Value="Green" />
                    </Trigger>
                    <Trigger Property="Text" Value="{x:Static resources:Resource.BootLogoWindow_SetDefaultSuccess}">
                        <Setter Property="Foreground" Value="Green" />
                    </Trigger>
                </Style.Triggers>
            </Style>
        </TextBlock.Style>
</TextBlock>
```

Here I use Trigger to set foreground color. Normally it's set as `Red`, and when the message is equal to success-messages, it will be set to `Green`.

I didn't use dynamic resources to set color because I don't know actually how I should do that (or if it's necessary at all), but I tried it in both bright mode and dark mode, both of them looks well to me.

<img width="319" alt="image" src="https://github.com/BartoszCichecki/LenovoLegionToolkit/assets/104905842/b0133363-920d-4a42-a99a-4405ec2a101b">
<img width="321" alt="image" src="https://github.com/BartoszCichecki/LenovoLegionToolkit/assets/104905842/b47282ad-7f80-4c8c-9437-09d6843eca43">

<img width="318" alt="image" src="https://github.com/BartoszCichecki/LenovoLegionToolkit/assets/104905842/bedc49b0-d7fd-4408-82bf-cebcc1d68f7e">
<img width="308" alt="image" src="https://github.com/BartoszCichecki/LenovoLegionToolkit/assets/104905842/32862c64-fd25-4a69-910a-d25b372fcb8b">

(btw. the `t:` in the error msg is only a debug sign, it has already been removed from code. I only forgot to rebuild)

I don't know if it will be better when using dynamic brush (e.g. bright red for error in dark mode), I didn't try it.

And also I used fixed margin here (`"0,82,0,0"`). It looks fine in all languages except Triditional Chinese (a bit weird).

<img width="318" alt="image" src="https://github.com/BartoszCichecki/LenovoLegionToolkit/assets/104905842/091f779b-6896-45d1-a9cd-35ebc646926a">
<img width="318" alt="image" src="https://github.com/BartoszCichecki/LenovoLegionToolkit/assets/104905842/d086a735-5390-42ec-99f5-6cd3e364198b">

(Triditional Chinese and Simplified Chinese to compare)

The translation of the description text in Triditional Chinese is way shorter than any other languages. It would be better if `_resultTextBlock` can be sticked directly under the `_descriptionTextBlock`, but I don't know how.