### PR TITLE
Switched to a more performant locking library

### DIFF
--- a/LenovoLegionToolkit.Lib.Automation/AutomationProcessor.cs
+++ b/LenovoLegionToolkit.Lib.Automation/AutomationProcessor.cs
@@ -10,7 +10,7 @@ using LenovoLegionToolkit.Lib.Automation.Utils;
 using LenovoLegionToolkit.Lib.Controllers.GodMode;
 using LenovoLegionToolkit.Lib.Listeners;
 using LenovoLegionToolkit.Lib.Utils;
-using NeoSmart.AsyncLock;
+using AsyncKeyedLock;
 
 namespace LenovoLegionToolkit.Lib.Automation;
 
@@ -27,8 +27,8 @@ public class AutomationProcessor
     private readonly UserInactivityAutoListener _userInactivityAutoListener;
     private readonly WiFiAutoListener _wifiAutoListener;
 
-    private readonly AsyncLock _ioLock = new();
-    private readonly AsyncLock _runLock = new();
+    private readonly AsyncNonKeyedLocker _ioLock = new();
+    private readonly AsyncNonKeyedLocker _runLock = new();
 
     private List<AutomationPipeline> _pipelines = new();
     private CancellationTokenSource? _cts;

--- a/LenovoLegionToolkit.Lib.Automation/LenovoLegionToolkit.Lib.Automation.csproj
+++ b/LenovoLegionToolkit.Lib.Automation/LenovoLegionToolkit.Lib.Automation.csproj
@@ -9,9 +9,9 @@
 		<NeutralLanguage>en</NeutralLanguage>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
 		<PackageReference Include="Autofac" Version="7.1.0" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 	<ItemGroup>

--- a/LenovoLegionToolkit.Lib/AutoListeners/AbstractAutoListener.cs
+++ b/LenovoLegionToolkit.Lib/AutoListeners/AbstractAutoListener.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Threading.Tasks;
 using LenovoLegionToolkit.Lib.Utils;
-using NeoSmart.AsyncLock;
+using AsyncKeyedLock;
 
 namespace LenovoLegionToolkit.Lib.AutoListeners;
 
 public abstract class AbstractAutoListener<T> : IAutoListener<T>
 {
-    private readonly AsyncLock _startStopLock = new();
+    private readonly AsyncNonKeyedLocker _startStopLock = new();
 
     private bool _started;
 

--- a/LenovoLegionToolkit.Lib/Controllers/AIController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/AIController.cs
@@ -10,7 +10,7 @@ using LenovoLegionToolkit.Lib.Settings;
 using LenovoLegionToolkit.Lib.System;
 using LenovoLegionToolkit.Lib.System.Management;
 using LenovoLegionToolkit.Lib.Utils;
-using NeoSmart.AsyncLock;
+using AsyncKeyedLock;
 
 namespace LenovoLegionToolkit.Lib.Controllers;
 
@@ -18,7 +18,7 @@ public class AIController
 {
     private readonly ThrottleLastDispatcher _dispatcher = new(TimeSpan.FromSeconds(1), nameof(AIController));
 
-    private readonly AsyncLock _startStopLock = new();
+    private readonly AsyncNonKeyedLocker _startStopLock = new();
 
     private readonly PowerModeListener _powerModeListener;
     private readonly PowerStateListener _powerStateListener;

--- a/LenovoLegionToolkit.Lib/Controllers/GPUController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/GPUController.cs
@@ -9,13 +9,13 @@ using LenovoLegionToolkit.Lib.Resources;
 using LenovoLegionToolkit.Lib.System;
 using LenovoLegionToolkit.Lib.System.Management;
 using LenovoLegionToolkit.Lib.Utils;
-using NeoSmart.AsyncLock;
+using AsyncKeyedLock;
 
 namespace LenovoLegionToolkit.Lib.Controllers;
 
 public class GPUController
 {
-    private readonly AsyncLock _lock = new();
+    private readonly AsyncNonKeyedLocker _lock = new();
 
     private Task? _refreshTask;
     private CancellationTokenSource? _refreshCancellationTokenSource;

--- a/LenovoLegionToolkit.Lib/Controllers/RGBKeyboardBacklightController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/RGBKeyboardBacklightController.cs
@@ -6,7 +6,7 @@ using Windows.Win32;
 using LenovoLegionToolkit.Lib.Extensions;
 using LenovoLegionToolkit.Lib.Settings;
 using LenovoLegionToolkit.Lib.System;
-using NeoSmart.AsyncLock;
+using AsyncKeyedLock;
 using LenovoLegionToolkit.Lib.Utils;
 using Microsoft.Win32.SafeHandles;
 using LenovoLegionToolkit.Lib.SoftwareDisabler;
@@ -20,7 +20,7 @@ namespace LenovoLegionToolkit.Lib.Controllers
 {
     public class RGBKeyboardBacklightController
     {
-        private static readonly AsyncLock IoLock = new();
+        private static readonly AsyncNonKeyedLocker IoLock = new();
 
         private readonly RGBKeyboardSettings _settings;
 

--- a/LenovoLegionToolkit.Lib/Controllers/SmartFnLockController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/SmartFnLockController.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using LenovoLegionToolkit.Lib.Features;
 using LenovoLegionToolkit.Lib.Settings;
 using LenovoLegionToolkit.Lib.Utils;
-using NeoSmart.AsyncLock;
+using AsyncKeyedLock;
 using Windows.Win32;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 using Windows.Win32.UI.WindowsAndMessaging;
@@ -12,7 +12,7 @@ namespace LenovoLegionToolkit.Lib.Controllers;
 
 public class SmartFnLockController
 {
-    private readonly AsyncLock _lock = new();
+    private readonly AsyncNonKeyedLocker _lock = new();
 
     private readonly FnLockFeature _feature;
     private readonly ApplicationSettings _settings;

--- a/LenovoLegionToolkit.Lib/Controllers/SpectrumKeyboardBacklightController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/SpectrumKeyboardBacklightController.cs
@@ -11,7 +11,7 @@ using LenovoLegionToolkit.Lib.SoftwareDisabler;
 using LenovoLegionToolkit.Lib.System;
 using LenovoLegionToolkit.Lib.Utils;
 using Microsoft.Win32.SafeHandles;
-using NeoSmart.AsyncLock;
+using AsyncKeyedLock;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Windows.Win32;
@@ -43,7 +43,7 @@ public class SpectrumKeyboardBacklightController
         }
     }
 
-    private static readonly AsyncLock GetDeviceHandleLock = new();
+    private static readonly AsyncNonKeyedLocker GetDeviceHandleLock = new();
     private static readonly object IoLock = new();
 
     private readonly TimeSpan _auroraRefreshInterval = TimeSpan.FromMilliseconds(60);

--- a/LenovoLegionToolkit.Lib/LenovoLegionToolkit.Lib.csproj
+++ b/LenovoLegionToolkit.Lib/LenovoLegionToolkit.Lib.csproj
@@ -10,6 +10,7 @@
 		<UseWindowsForms>true</UseWindowsForms>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
 		<PackageReference Include="Autofac" Version="7.1.0" />
 		<PackageReference Include="Ben.Demystifier" Version="0.4.1" />
 		<PackageReference Include="CoordinateSharp" Version="2.21.1.1" />
@@ -23,7 +24,6 @@
 		<PackageReference Include="PubSub" Version="4.0.2" />
 		<PackageReference Include="System.Management" Version="8.0.0" />
 		<PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
-		<PackageReference Include="NeoSmart.AsyncLock" Version="3.2.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NvAPIWrapper.Net" Version="0.8.1.101" />
 		<PackageReference Include="Octokit" Version="9.1.0" />

--- a/LenovoLegionToolkit.Lib/Utils/ThrottleFirstDispatcher.cs
+++ b/LenovoLegionToolkit.Lib/Utils/ThrottleFirstDispatcher.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Threading.Tasks;
-using NeoSmart.AsyncLock;
+using AsyncKeyedLock;
 
 namespace LenovoLegionToolkit.Lib.Utils;
 
 public class ThrottleFirstDispatcher
 {
-    private readonly AsyncLock _lock = new();
+    private readonly AsyncNonKeyedLocker _lock = new();
 
     private readonly TimeSpan _interval;
     private readonly string? _tag;

--- a/LenovoLegionToolkit.Lib/Utils/UpdateChecker.cs
+++ b/LenovoLegionToolkit.Lib/Utils/UpdateChecker.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using LenovoLegionToolkit.Lib.Extensions;
-using NeoSmart.AsyncLock;
+using AsyncKeyedLock;
 using Octokit;
 using Octokit.Internal;
 
@@ -14,7 +14,7 @@ namespace LenovoLegionToolkit.Lib.Utils;
 public class UpdateChecker
 {
     private readonly TimeSpan _minimumTimeSpanForRefresh = new(hours: 3, minutes: 0, seconds: 0);
-    private readonly AsyncLock _updateSemaphore = new();
+    private readonly AsyncNonKeyedLocker _updateSemaphore = new();
 
     private readonly HttpClientFactory _httpClientFactory;
 

--- a/LenovoLegionToolkit.WPF/Pages/AboutPage.xaml
+++ b/LenovoLegionToolkit.WPF/Pages/AboutPage.xaml
@@ -65,7 +65,7 @@
 
             <StackPanel Grid.Column="0" Margin="0,0,32,0">
                 <wpfui:Hyperlink Content="Autofac" NavigateUri="https://github.com/autofac/Autofac" />
-                <wpfui:Hyperlink Content="AsyncLock" NavigateUri="https://github.com/neosmart/AsyncLock" />
+                <wpfui:Hyperlink Content="AsyncNonKeyedLocker" NavigateUri="https://github.com/neosmart/AsyncNonKeyedLocker" />
                 <wpfui:Hyperlink Content="ColorPicker" NavigateUri="https://github.com/PixiEditor/ColorPicker" />
                 <wpfui:Hyperlink Content="CsWin32" NavigateUri="https://github.com/microsoft/CsWin32" />
                 <wpfui:Hyperlink Content="Demystifier" NavigateUri="https://github.com/benaadams/Ben.Demystifier" />

--- a/LenovoLegionToolkit.WPF/Pages/AboutPage.xaml
+++ b/LenovoLegionToolkit.WPF/Pages/AboutPage.xaml
@@ -64,8 +64,8 @@
             </Grid.ColumnDefinitions>
 
             <StackPanel Grid.Column="0" Margin="0,0,32,0">
+                <wpfui:Hyperlink Content="AsyncKeyedLock" NavigateUri="https://github.com/MarkCiliaVincenti/AsyncKeyedLock" />
                 <wpfui:Hyperlink Content="Autofac" NavigateUri="https://github.com/autofac/Autofac" />
-                <wpfui:Hyperlink Content="AsyncNonKeyedLocker" NavigateUri="https://github.com/neosmart/AsyncNonKeyedLocker" />
                 <wpfui:Hyperlink Content="ColorPicker" NavigateUri="https://github.com/PixiEditor/ColorPicker" />
                 <wpfui:Hyperlink Content="CsWin32" NavigateUri="https://github.com/microsoft/CsWin32" />
                 <wpfui:Hyperlink Content="Demystifier" NavigateUri="https://github.com/benaadams/Ben.Demystifier" />


### PR DESCRIPTION
Disclaimer: I am the author of the new library.

Public benchmarks running on GitHub show AsyncNonKeyedLocker to be considerably more performant; in tests NeoSmart.AsyncLock took 9.71x the time and allocated 7.42x the memory.

https://github.com/MarkCiliaVincenti/AsyncNonKeyedLockBenchmarks/actions/runs/7526873065/job/20485876144