### PR TITLE
Added an option to reset the On Battery Timer on restart

### DIFF
--- a/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
@@ -44,7 +44,7 @@ public class ApplicationSettings : AbstractSettings<ApplicationSettings.Applicat
         public List<Guid> SmartKeyDoublePressActionList { get; set; } = new();
         public bool SynchronizeBrightnessToAllPowerPlans { get; set; }
         public ModifierKey SmartFnLockFlags { get; set; }
-        public bool? ResetBatteryOnSinceTimerOnReboot { get; set; }
+        public bool ResetBatteryOnSinceTimerOnReboot { get; set; }
     }
 
     public ApplicationSettings() : base("settings.json")

--- a/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
@@ -44,6 +44,7 @@ public class ApplicationSettings : AbstractSettings<ApplicationSettings.Applicat
         public List<Guid> SmartKeyDoublePressActionList { get; set; } = new();
         public bool SynchronizeBrightnessToAllPowerPlans { get; set; }
         public ModifierKey SmartFnLockFlags { get; set; }
+        public bool? ResetBatteryOnSinceTimerOnReboot { get; set; }
     }
 
     public ApplicationSettings() : base("settings.json")

--- a/LenovoLegionToolkit.Lib/System/Battery.cs
+++ b/LenovoLegionToolkit.Lib/System/Battery.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Eventing.Reader;
 using System.Linq;
 using LenovoLegionToolkit.Lib.Extensions;
+using LenovoLegionToolkit.Lib.Settings;
 using LenovoLegionToolkit.Lib.Utils;
 using Windows.Win32;
 using Windows.Win32.System.Power;
@@ -11,6 +12,7 @@ namespace LenovoLegionToolkit.Lib.System;
 
 public static class Battery
 {
+    private static readonly ApplicationSettings _settings = IoCContainer.Resolve<ApplicationSettings>();
     public static BatteryInformation GetBatteryInformation()
     {
         var powerStatus = GetSystemPowerStatus();
@@ -75,6 +77,9 @@ public static class Battery
     {
         try
         {
+            var resetOnReboot = _settings.Store.ResetBatteryOnSinceTimerOnReboot ?? false;
+            var lastRebootTime = DateTime.Now - TimeSpan.FromMilliseconds(Environment.TickCount);
+
             var logs = new List<(DateTime Date, bool IsACOnline)>();
 
             var query = new EventLogQuery("System", PathType.LogName, "*[System[EventID=105]]");
@@ -89,15 +94,22 @@ public static class Battery
                 if (date is null || isAcOnline is null)
                     continue;
 
+                if (resetOnReboot && date < lastRebootTime)
+                    continue;
+
                 logs.Add((date.Value, isAcOnline.Value));
             }
 
             if (logs.Count < 1)
                 return null;
 
-            var (dateTime, isACOnline) = logs.MaxBy(l => l.Date);
-            if (!isACOnline)
-                return dateTime;
+            logs.Reverse();
+
+            var firstLastAcOffEvent = logs
+                .TakeWhile(log => log.IsACOnline != true)
+                .LastOrDefault();
+
+            return firstLastAcOffEvent.Date;
         }
         catch (Exception ex)
         {

--- a/LenovoLegionToolkit.Lib/System/Battery.cs
+++ b/LenovoLegionToolkit.Lib/System/Battery.cs
@@ -13,6 +13,7 @@ namespace LenovoLegionToolkit.Lib.System;
 public static class Battery
 {
     private static readonly ApplicationSettings _settings = IoCContainer.Resolve<ApplicationSettings>();
+    
     public static BatteryInformation GetBatteryInformation()
     {
         var powerStatus = GetSystemPowerStatus();
@@ -77,8 +78,11 @@ public static class Battery
     {
         try
         {
-            var resetOnReboot = _settings.Store.ResetBatteryOnSinceTimerOnReboot ?? false;
-            var lastRebootTime = DateTime.Now - TimeSpan.FromMilliseconds(Environment.TickCount);
+            var resetOnReboot = _settings.Store.ResetBatteryOnSinceTimerOnReboot;
+
+            DateTime lastRebootTime = new();
+            if (resetOnReboot)
+                lastRebootTime = DateTime.Now - TimeSpan.FromMilliseconds(Environment.TickCount);
 
             var logs = new List<(DateTime Date, bool IsACOnline)>();
 

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml
@@ -227,6 +227,18 @@
                 Symbol="Open24" />
         </custom:CardControl>
 
+        <custom:CardControl Margin="0,0,0,24">
+            <custom:CardControl.Header>
+                <controls:CardHeaderControl Title="{x:Static resources:Resource.SettingsPage_OnBatterySinceReset_Title}" Subtitle="{x:Static resources:Resource.SettingsPage_OnBatterySinceReset_Message}" />
+            </custom:CardControl.Header>
+            <wpfui:ToggleSwitch
+                x:Name="_onBatterySinceResetToggle"
+                Margin="0,0,0,8"
+                AutomationProperties.Name="{x:Static resources:Resource.SettingsPage_OnBatterySinceReset_Title}"
+                Click="OnBatterySinceResetToggle_Click"
+                Visibility="Hidden" />
+        </custom:CardControl>
+
         <TextBlock
             Margin="0,16,0,24"
             AutomationProperties.Name="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Text}"

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
@@ -105,7 +105,7 @@ public partial class SettingsPage
         _notificationsCard.Visibility = fnKeysStatus != SoftwareStatus.Enabled ? Visibility.Visible : Visibility.Collapsed;
         _excludeRefreshRatesCard.Visibility = fnKeysStatus != SoftwareStatus.Enabled ? Visibility.Visible : Visibility.Collapsed;
         _synchronizeBrightnessToAllPowerPlansToggle.IsChecked = _settings.Store.SynchronizeBrightnessToAllPowerPlans;
-        _onBatterySinceResetToggle.IsChecked = _settings.Store.ResetBatteryOnSinceTimerOnReboot ?? false;
+        _onBatterySinceResetToggle.IsChecked = _settings.Store.ResetBatteryOnSinceTimerOnReboot;
 
         _bootLogoCard.Visibility = await BootLogo.IsSupportedAsync() ? Visibility.Visible : Visibility.Collapsed;
 

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
@@ -105,10 +105,12 @@ public partial class SettingsPage
         _notificationsCard.Visibility = fnKeysStatus != SoftwareStatus.Enabled ? Visibility.Visible : Visibility.Collapsed;
         _excludeRefreshRatesCard.Visibility = fnKeysStatus != SoftwareStatus.Enabled ? Visibility.Visible : Visibility.Collapsed;
         _synchronizeBrightnessToAllPowerPlansToggle.IsChecked = _settings.Store.SynchronizeBrightnessToAllPowerPlans;
+        _onBatterySinceResetToggle.IsChecked = _settings.Store.ResetBatteryOnSinceTimerOnReboot ?? false;
 
         _bootLogoCard.Visibility = await BootLogo.IsSupportedAsync() ? Visibility.Visible : Visibility.Collapsed;
 
         _powerPlansCard.Visibility = await _powerModeFeature.IsSupportedAsync() ? Visibility.Visible : Visibility.Collapsed;
+        _onBatterySinceResetToggle.Visibility = Visibility.Visible;
 
         _hwinfoIntegrationToggle.IsChecked = _integrationsSettings.Store.HWiNFO;
 
@@ -494,6 +496,19 @@ public partial class SettingsPage
     private void PowerPlansControlPanel_Click(object sender, RoutedEventArgs e)
     {
         Process.Start("control", "/name Microsoft.PowerOptions");
+    }
+
+    private void OnBatterySinceResetToggle_Click(object sender, RoutedEventArgs e)
+    {
+        if (_isRefreshing)
+            return;
+
+        var state = _onBatterySinceResetToggle.IsChecked;
+        if (state is null)
+            return;
+
+        _settings.Store.ResetBatteryOnSinceTimerOnReboot = state.Value;
+        _settings.SynchronizeStore();
     }
 
     private async void HWiNFOIntegrationToggle_Click(object sender, RoutedEventArgs e)

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -4781,6 +4781,24 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Resets the counter for &quot;On battery since&quot; in the battery section when the system reboots..
+        /// </summary>
+        public static string SettingsPage_OnBatterySinceReset_Message {
+            get {
+                return ResourceManager.GetString("SettingsPage_OnBatterySinceReset_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reset &quot;On battery since&quot; at startup.
+        /// </summary>
+        public static string SettingsPage_OnBatterySinceReset_Title {
+            get {
+                return ResourceManager.GetString("SettingsPage_OnBatterySinceReset_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Power.
         /// </summary>
         public static string SettingsPage_Power_Title {

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -1988,48 +1988,54 @@ Supported formats are: {1}.</value>
     <value>Custom boot logo set.</value>
   </data>
   <data name="WiFiConnectedPipelineTriggerTabItemContent_NetworkName" xml:space="preserve">
-	  <value>Network name (SSID)</value>
+    <value>Network name (SSID)</value>
   </data>
   <data name="WiFiConnectedPipelineTriggerTabItemContent_CopyCurrentNetworkName" xml:space="preserve">
-	  <value>Copy current network name</value>
+    <value>Copy current network name</value>
   </data>
   <data name="WiFiConnectedPipelineTriggerTabItemContent_LeaveEmptyForAnyNetwork" xml:space="preserve">
-	  <value>Leave empty for any Wi-Fi network.</value>
+    <value>Leave empty for any Wi-Fi network.</value>
   </data>
   <data name="SettingsPage_HWiNFO_Title" xml:space="preserve">
-	  <value>HWiNFO64</value>
+    <value>HWiNFO64</value>
   </data>
   <data name="SettingsPage_HWiNFO_Message" xml:space="preserve">
-	  <value>Share fan speed, battery temperature etc. with HWiNFO64. You may need to restart HWiNFO64 after changing this option.</value>
+    <value>Share fan speed, battery temperature etc. with HWiNFO64. You may need to restart HWiNFO64 after changing this option.</value>
   </data>
   <data name="SettingsPage_Integrations_Title" xml:space="preserve">
-	  <value>Integrations</value>
+    <value>Integrations</value>
   </data>
   <data name="Settings" xml:space="preserve">
-	  <value>Settings</value>
+    <value>Settings</value>
   </data>
   <data name="Information" xml:space="preserve">
-	  <value>Information</value>
+    <value>Information</value>
   </data>
   <data name="PackagesPage_DownloadTo" xml:space="preserve">
-	  <value>Download folder</value>
+    <value>Download folder</value>
   </data>
   <data name="PackagesPage_OpenDownloadTo" xml:space="preserve">
-	  <value>Open Download folder</value>
+    <value>Open Download folder</value>
   </data>
   <data name="PackageControl_Download" xml:space="preserve">
-	  <value>Download</value>
+    <value>Download</value>
   </data>
   <data name="PackageControl_OpenReadme" xml:space="preserve">
-	  <value>Open README</value>
+    <value>Open README</value>
   </data>
   <data name="SpectrumKeyboardBacklightControl_Preset" xml:space="preserve">
-	  <value>Preset</value>
+    <value>Preset</value>
   </data>
   <data name="DeviceInformationWindow_Refresh" xml:space="preserve">
-	  <value>Refresh</value>
+    <value>Refresh</value>
   </data>
   <data name="AbstractAutomationStepControl_Delete" xml:space="preserve">
-	  <value>Delete</value>
+    <value>Delete</value>
+  </data>
+  <data name="SettingsPage_OnBatterySinceReset_Message" xml:space="preserve">
+    <value>Resets the counter for "On battery since" in the battery section when the system reboots.</value>
+  </data>
+  <data name="SettingsPage_OnBatterySinceReset_Title" xml:space="preserve">
+    <value>Reset "On battery since" at startup</value>
   </data>
 </root>


### PR DESCRIPTION
Added a toggle in the Power settings. Now the tracker correctly measures the time on system restart. Implements suggestion 1 from https://github.com/BartoszCichecki/LenovoLegionToolkit/issues/1077.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new feature for resetting the "On battery since" timer on reboot, enhancing battery management.
- **Enhancements**
	- Added a toggle switch in the settings for users to enable or disable the battery reset feature.
- **Documentation**
	- Updated resource files with new entries for better clarity on the battery reset feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->