### PR TITLE
Add percentage drain

### DIFF
--- a/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
@@ -44,11 +44,8 @@ public class ApplicationSettings : AbstractSettings<ApplicationSettings.Applicat
         public List<Guid> SmartKeyDoublePressActionList { get; set; } = new();
         public bool SynchronizeBrightnessToAllPowerPlans { get; set; }
         public ModifierKey SmartFnLockFlags { get; set; }
-<<<<<<< HEAD
         public bool IsDischargePercentageBasedOnRemainingCharge {get; set;}
-=======
         public bool ResetBatteryOnSinceTimerOnReboot { get; set; }
->>>>>>> master
     }
 
     public ApplicationSettings() : base("settings.json")

--- a/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
@@ -44,6 +44,7 @@ public class ApplicationSettings : AbstractSettings<ApplicationSettings.Applicat
         public List<Guid> SmartKeyDoublePressActionList { get; set; } = new();
         public bool SynchronizeBrightnessToAllPowerPlans { get; set; }
         public ModifierKey SmartFnLockFlags { get; set; }
+        public bool IsDischargePercentageBasedOnRemainingCharge {get; set;}
     }
 
     public ApplicationSettings() : base("settings.json")

--- a/LenovoLegionToolkit.WPF/Pages/BatteryPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/BatteryPage.xaml.cs
@@ -118,8 +118,13 @@ public partial class BatteryPage
             _onBatterySinceText.Text = "-";
         }
 
-        var dischargeRateWatts = batteryInfo.DischargeRate / 1000.0 ;
-        var dischargePercentage = dischargeRateWatts / (batteryInfo.EstimateChargeRemaining / 1000.0);
+        var dischargeRateWatts = batteryInfo.DischargeRate / 1000.0;
+        double dischargePercentage;
+        if (_settings.Store.IsDischargePercentageBasedOnRemainingCharge)
+            dischargePercentage = dischargeRateWatts / (batteryInfo.EstimateChargeRemaining / 1000.0);
+        else
+            dischargePercentage = dischargeRateWatts / (batteryInfo.FullChargeCapacity / 1000.0);
+
         _batteryDischargeRateText.Text = $"{dischargeRateWatts:+0.00;-0.00;0.00} W ({dischargePercentage:+0.00%;-0.00%;0.00%})";
         _batteryCapacityText.Text = $"{batteryInfo.EstimateChargeRemaining / 1000.0:0.00} Wh";
         _batteryFullChargeCapacityText.Text = $"{batteryInfo.FullChargeCapacity / 1000.0:0.00} Wh";

--- a/LenovoLegionToolkit.WPF/Pages/BatteryPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/BatteryPage.xaml.cs
@@ -118,7 +118,9 @@ public partial class BatteryPage
             _onBatterySinceText.Text = "-";
         }
 
-        _batteryDischargeRateText.Text = $"{batteryInfo.DischargeRate / 1000.0:+0.00;-0.00;0.00} W";
+        var dischargeRateWatts = batteryInfo.DischargeRate / 1000.0 ;
+        var dischargePercentage = dischargeRateWatts / (batteryInfo.EstimateChargeRemaining / 1000.0);
+        _batteryDischargeRateText.Text = $"{dischargeRateWatts:+0.00;-0.00;0.00} W ({dischargePercentage:+0.00%;-0.00%;0.00%})";
         _batteryCapacityText.Text = $"{batteryInfo.EstimateChargeRemaining / 1000.0:0.00} Wh";
         _batteryFullChargeCapacityText.Text = $"{batteryInfo.FullChargeCapacity / 1000.0:0.00} Wh";
         _batteryDesignCapacityText.Text = $"{batteryInfo.DesignCapacity / 1000.0:0.00} Wh";

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml
@@ -227,6 +227,18 @@
                 Symbol="Open24" />
         </custom:CardControl>
 
+        <custom:CardControl Margin="0,0,0,24">
+            <custom:CardControl.Header>
+                <controls:CardHeaderControl Title="{x:Static resources:Resource.SettingsPage_DischargePercentageBasedOnRemainingCharge_Title}" Subtitle="{x:Static resources:Resource.SettingsPage_DischargePercentageBasedOnRemainingCharge_Message}" />
+            </custom:CardControl.Header>
+            <wpfui:ToggleSwitch
+                x:Name="_dischargePercentageBasedOnRemainingChargeToggle"
+                Margin="0,0,0,8"
+                AutomationProperties.Name="{x:Static resources:Resource.SettingsPage_DischargePercentageBasedOnRemainingCharge_Title}"
+                Click="OnDischargePercentageBasedOnRemainingChargeToggle_Click"
+                Visibility="Hidden" />
+        </custom:CardControl>
+
         <TextBlock
             Margin="0,16,0,24"
             AutomationProperties.Name="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Text}"

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml
@@ -217,7 +217,7 @@
             </custom:CardAction.Content>
         </custom:CardAction>
 
-        <custom:CardControl Margin="0,0,0,8" Click="PowerPlansControlPanel_Click">
+        <custom:CardControl Margin="0,0,0,24" Click="PowerPlansControlPanel_Click">
             <custom:CardControl.Header>
                 <controls:CardHeaderControl Title="{x:Static resources:Resource.SettingsPage_PowerPlansControlPanel_Title}" />
             </custom:CardControl.Header>
@@ -227,7 +227,7 @@
                 Symbol="Open24" />
         </custom:CardControl>
 
-        <custom:CardControl Margin="0,0,0,24">
+        <custom:CardControl Margin="0,0,0,8">
             <custom:CardControl.Header>
                 <controls:CardHeaderControl Title="{x:Static resources:Resource.SettingsPage_OnBatterySinceReset_Title}" Subtitle="{x:Static resources:Resource.SettingsPage_OnBatterySinceReset_Message}" />
             </custom:CardControl.Header>
@@ -239,7 +239,7 @@
                 Visibility="Hidden" />
         </custom:CardControl>
 
-        <custom:CardControl Margin="0,0,0,24">
+        <custom:CardControl Margin="0,0,0,8">
             <custom:CardControl.Header>
                 <controls:CardHeaderControl Title="{x:Static resources:Resource.SettingsPage_DischargePercentageBasedOnRemainingCharge_Title}" Subtitle="{x:Static resources:Resource.SettingsPage_DischargePercentageBasedOnRemainingCharge_Message}" />
             </custom:CardControl.Header>

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
@@ -105,20 +105,14 @@ public partial class SettingsPage
         _notificationsCard.Visibility = fnKeysStatus != SoftwareStatus.Enabled ? Visibility.Visible : Visibility.Collapsed;
         _excludeRefreshRatesCard.Visibility = fnKeysStatus != SoftwareStatus.Enabled ? Visibility.Visible : Visibility.Collapsed;
         _synchronizeBrightnessToAllPowerPlansToggle.IsChecked = _settings.Store.SynchronizeBrightnessToAllPowerPlans;
-<<<<<<< HEAD
         _dischargePercentageBasedOnRemainingChargeToggle.IsChecked = _settings.Store.IsDischargePercentageBasedOnRemainingCharge;
-=======
         _onBatterySinceResetToggle.IsChecked = _settings.Store.ResetBatteryOnSinceTimerOnReboot;
->>>>>>> master
 
         _bootLogoCard.Visibility = await BootLogo.IsSupportedAsync() ? Visibility.Visible : Visibility.Collapsed;
 
         _powerPlansCard.Visibility = await _powerModeFeature.IsSupportedAsync() ? Visibility.Visible : Visibility.Collapsed;
-<<<<<<< HEAD
         _dischargePercentageBasedOnRemainingChargeToggle.Visibility = Visibility.Visible;
-=======
         _onBatterySinceResetToggle.Visibility = Visibility.Visible;
->>>>>>> master
 
         _hwinfoIntegrationToggle.IsChecked = _integrationsSettings.Store.HWiNFO;
 

--- a/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/SettingsPage.xaml.cs
@@ -105,10 +105,12 @@ public partial class SettingsPage
         _notificationsCard.Visibility = fnKeysStatus != SoftwareStatus.Enabled ? Visibility.Visible : Visibility.Collapsed;
         _excludeRefreshRatesCard.Visibility = fnKeysStatus != SoftwareStatus.Enabled ? Visibility.Visible : Visibility.Collapsed;
         _synchronizeBrightnessToAllPowerPlansToggle.IsChecked = _settings.Store.SynchronizeBrightnessToAllPowerPlans;
+        _dischargePercentageBasedOnRemainingChargeToggle.IsChecked = _settings.Store.IsDischargePercentageBasedOnRemainingCharge;
 
         _bootLogoCard.Visibility = await BootLogo.IsSupportedAsync() ? Visibility.Visible : Visibility.Collapsed;
 
         _powerPlansCard.Visibility = await _powerModeFeature.IsSupportedAsync() ? Visibility.Visible : Visibility.Collapsed;
+        _dischargePercentageBasedOnRemainingChargeToggle.Visibility = Visibility.Visible;
 
         _hwinfoIntegrationToggle.IsChecked = _integrationsSettings.Store.HWiNFO;
 
@@ -494,6 +496,19 @@ public partial class SettingsPage
     private void PowerPlansControlPanel_Click(object sender, RoutedEventArgs e)
     {
         Process.Start("control", "/name Microsoft.PowerOptions");
+    }
+
+    private void OnDischargePercentageBasedOnRemainingChargeToggle_Click(object sender, RoutedEventArgs e)
+    {
+        if (_isRefreshing)
+            return;
+
+        var state = _dischargePercentageBasedOnRemainingChargeToggle.IsChecked;
+        if (state is null)
+            return;
+
+        _settings.Store.IsDischargePercentageBasedOnRemainingCharge = state.Value;
+        _settings.SynchronizeStore();
     }
 
     private async void HWiNFOIntegrationToggle_Click(object sender, RoutedEventArgs e)

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -4637,7 +4637,7 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to When toggled, the discharge rate in percentage will be calculated based on the remaining charge. Otherwise, it will be calculated based on the full charg capacity..
+        ///   Looks up a localized string similar to When enabled, the battery discharge rate percentage will be calculated based on the remaining battery charge. If disabled, it will be calculated based on the total battery capacity..
         /// </summary>
         public static string SettingsPage_DischargePercentageBasedOnRemainingCharge_Message {
             get {

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -4628,6 +4628,24 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to When toggled, the discharge rate in percentage will be calculated based on the remaining charge. Otherwise, it will be calculated based on the full charg capacity..
+        /// </summary>
+        public static string SettingsPage_DischargePercentageBasedOnRemainingCharge_Message {
+            get {
+                return ResourceManager.GetString("SettingsPage_DischargePercentageBasedOnRemainingCharge_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Discharge percentage based on remaining charge.
+        /// </summary>
+        public static string SettingsPage_DischargePercentageBasedOnRemainingCharge_Title {
+            get {
+                return ResourceManager.GetString("SettingsPage_DischargePercentageBasedOnRemainingCharge_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Legion Zone may have not been enabled correctly.
         /// </summary>
         public static string SettingsPage_EnableLegionZone_Error_Message {

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -1988,48 +1988,54 @@ Supported formats are: {1}.</value>
     <value>Custom boot logo set.</value>
   </data>
   <data name="WiFiConnectedPipelineTriggerTabItemContent_NetworkName" xml:space="preserve">
-	  <value>Network name (SSID)</value>
+    <value>Network name (SSID)</value>
   </data>
   <data name="WiFiConnectedPipelineTriggerTabItemContent_CopyCurrentNetworkName" xml:space="preserve">
-	  <value>Copy current network name</value>
+    <value>Copy current network name</value>
   </data>
   <data name="WiFiConnectedPipelineTriggerTabItemContent_LeaveEmptyForAnyNetwork" xml:space="preserve">
-	  <value>Leave empty for any Wi-Fi network.</value>
+    <value>Leave empty for any Wi-Fi network.</value>
   </data>
   <data name="SettingsPage_HWiNFO_Title" xml:space="preserve">
-	  <value>HWiNFO64</value>
+    <value>HWiNFO64</value>
   </data>
   <data name="SettingsPage_HWiNFO_Message" xml:space="preserve">
-	  <value>Share fan speed, battery temperature etc. with HWiNFO64. You may need to restart HWiNFO64 after changing this option.</value>
+    <value>Share fan speed, battery temperature etc. with HWiNFO64. You may need to restart HWiNFO64 after changing this option.</value>
   </data>
   <data name="SettingsPage_Integrations_Title" xml:space="preserve">
-	  <value>Integrations</value>
+    <value>Integrations</value>
   </data>
   <data name="Settings" xml:space="preserve">
-	  <value>Settings</value>
+    <value>Settings</value>
   </data>
   <data name="Information" xml:space="preserve">
-	  <value>Information</value>
+    <value>Information</value>
   </data>
   <data name="PackagesPage_DownloadTo" xml:space="preserve">
-	  <value>Download folder</value>
+    <value>Download folder</value>
   </data>
   <data name="PackagesPage_OpenDownloadTo" xml:space="preserve">
-	  <value>Open Download folder</value>
+    <value>Open Download folder</value>
   </data>
   <data name="PackageControl_Download" xml:space="preserve">
-	  <value>Download</value>
+    <value>Download</value>
   </data>
   <data name="PackageControl_OpenReadme" xml:space="preserve">
-	  <value>Open README</value>
+    <value>Open README</value>
   </data>
   <data name="SpectrumKeyboardBacklightControl_Preset" xml:space="preserve">
-	  <value>Preset</value>
+    <value>Preset</value>
   </data>
   <data name="DeviceInformationWindow_Refresh" xml:space="preserve">
-	  <value>Refresh</value>
+    <value>Refresh</value>
   </data>
   <data name="AbstractAutomationStepControl_Delete" xml:space="preserve">
-	  <value>Delete</value>
+    <value>Delete</value>
+  </data>
+  <data name="SettingsPage_DischargePercentageBasedOnRemainingCharge_Message" xml:space="preserve">
+    <value>When toggled, the discharge rate in percentage will be calculated based on the remaining charge. Otherwise, it will be calculated based on the full charg capacity.</value>
+  </data>
+  <data name="SettingsPage_DischargePercentageBasedOnRemainingCharge_Title" xml:space="preserve">
+    <value>Discharge percentage based on remaining charge</value>
   </data>
 </root>

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -2033,10 +2033,11 @@ Supported formats are: {1}.</value>
     <value>Delete</value>
   </data>
   <data name="SettingsPage_DischargePercentageBasedOnRemainingCharge_Message" xml:space="preserve">
-    <value>When toggled, the discharge rate in percentage will be calculated based on the remaining charge. Otherwise, it will be calculated based on the full charg capacity.</value>
+    <value>When enabled, the battery discharge rate percentage will be calculated based on the remaining battery charge. If disabled, it will be calculated based on the total battery capacity.</value>
   </data>
   <data name="SettingsPage_DischargePercentageBasedOnRemainingCharge_Title" xml:space="preserve">
     <value>Discharge percentage based on remaining charge</value>
+  </data>
   <data name="PeriodicActionPipelineTriggerTabItemContent_PeriodMinutes" xml:space="preserve">
     <value>Period (minutes)</value>
     <comment>A prompt that is used both to ask the user to input an integer, representing the number of minutes between two periodic actions are triggered, and to inform the user what have they set once they are done configuring the action.</comment>


### PR DESCRIPTION
Should close https://github.com/BartoszCichecki/LenovoLegionToolkit/issues/1077. Implements percentage drainage calculation per hour. I also added an option to calculate it based on remaining or total charge because I couldn't decide which one is better.

Default:

![image](https://github.com/BartoszCichecki/LenovoLegionToolkit/assets/49730291/bef045af-ff55-4785-9262-c0dacd1ac74e)

Setting:

![image](https://github.com/BartoszCichecki/LenovoLegionToolkit/assets/49730291/f7d65e1a-7fd7-4fe7-8bdc-58f37225681c)

Toggled:

![image](https://github.com/BartoszCichecki/LenovoLegionToolkit/assets/49730291/b25da9d6-50a0-4d39-bfa1-3b69b4efd513)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added an option to calculate battery discharge percentage based on remaining charge or full charge capacity.
	- Introduced a new toggle in settings for managing the discharge percentage calculation preference.

- **Enhancements**
	- Updated user interface elements and text values across various settings and information pages for clarity and additional functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->