### PR TITLE
Make WiFi Automation Trigger Displayname translatable

### DIFF
--- a/LenovoLegionToolkit.Lib.Automation/Pipeline/Triggers/WiFiConnectedAutomationPipelineTrigger.cs
+++ b/LenovoLegionToolkit.Lib.Automation/Pipeline/Triggers/WiFiConnectedAutomationPipelineTrigger.cs
@@ -3,13 +3,14 @@ using System.Linq;
 using System.Threading.Tasks;
 using LenovoLegionToolkit.Lib.Extensions;
 using LenovoLegionToolkit.Lib.System;
+using LenovoLegionToolkit.Lib.Automation.Resources;
 using Newtonsoft.Json;
 
 namespace LenovoLegionToolkit.Lib.Automation.Pipeline.Triggers;
 
 public class WiFiConnectedAutomationPipelineTrigger : IWiFiConnectedPipelineTrigger
 {
-    public string DisplayName => "When WiFi is connected";
+    public string DisplayName => Resource.WiFiConnectedAutomationPipelineTrigger_DisplayName;
 
     public string[] Ssids { get; }
 

--- a/LenovoLegionToolkit.Lib.Automation/Pipeline/Triggers/WiFiDisconnectedAutomationPipelineTrigger.cs
+++ b/LenovoLegionToolkit.Lib.Automation/Pipeline/Triggers/WiFiDisconnectedAutomationPipelineTrigger.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Threading.Tasks;
 using LenovoLegionToolkit.Lib.System;
+using LenovoLegionToolkit.Lib.Automation.Resources;
 
 namespace LenovoLegionToolkit.Lib.Automation.Pipeline.Triggers;
 
 public class WiFiDisconnectedAutomationPipelineTrigger : IWiFiDisconnectedPipelineTrigger
 {
-    public string DisplayName => "When WiFi is disconnected";
+    public string DisplayName => Resource.WiFiDisconnectedAutomationPipelineTrigger_DisplayName;
 
     public Task<bool> IsMatchingEvent(IAutomationEvent automationEvent)
     {

--- a/LenovoLegionToolkit.Lib.Automation/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.Lib.Automation/Resources/Resource.Designer.cs
@@ -302,5 +302,23 @@ namespace LenovoLegionToolkit.Lib.Automation.Resources {
                 return ResourceManager.GetString("UserInactivityAutomationPipelineTrigger_DisplayName_Zero", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When WiFi is connected.
+        /// </summary>
+        public static string WiFiConnectedAutomationPipelineTrigger_DisplayName {
+            get {
+                return ResourceManager.GetString("WiFiConnectedAutomationPipelineTrigger_DisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When WiFi is disconnected.
+        /// </summary>
+        public static string WiFiDisconnectedAutomationPipelineTrigger_DisplayName {
+            get {
+                return ResourceManager.GetString("WiFiDisconnectedAutomationPipelineTrigger_DisplayName", resourceCulture);
+            }
+        }
     }
 }

--- a/LenovoLegionToolkit.Lib.Automation/Resources/Resource.resx
+++ b/LenovoLegionToolkit.Lib.Automation/Resources/Resource.resx
@@ -200,4 +200,10 @@
     <value>Periodic action</value>
     <comment>The display name of the periodic automation action.</comment>
   </data>
+  <data name="WiFiConnectedAutomationPipelineTrigger_DisplayName" xml:space="preserve">
+    <value>When WiFi is connected</value>
+  </data>
+  <data name="WiFiDisconnectedAutomationPipelineTrigger_DisplayName" xml:space="preserve">
+    <value>When WiFi is disconnected</value>
+  </data>
 </root>


### PR DESCRIPTION
Fix: #1194 

Simply add two strings in `LenovoLegionToolkit.Lib.Automation\Resources\Resource.resx` and import them in `LenovoLegionToolkit.Lib.Automation/Pipeline/Triggers/WiFiConnectedAutomationPipelineTrigger.cs` and `LenovoLegionToolkit.Lib.Automation/Pipeline/Triggers/WiFiDisconnectedAutomationPipelineTrigger.cs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved localization support for WiFi connection status automation triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->