### PR TITLE
RunAutomationStepControl Improvements

### DIFF
--- a/LenovoLegionToolkit.Lib.Automation/Steps/RunAutomationStep.cs
+++ b/LenovoLegionToolkit.Lib.Automation/Steps/RunAutomationStep.cs
@@ -10,12 +10,12 @@ public class RunAutomationStep : IAutomationStep
 
     public string? ScriptArguments { get; }
 
-    public bool? RunSilently { get; }
+    public bool RunSilently { get; }
 
-    public bool? WaitUntilFinished { get; }
+    public bool WaitUntilFinished { get; }
 
     [JsonConstructor]
-    public RunAutomationStep(string? scriptPath, string? scriptArguments, bool? runSilently, bool? waitUntilFinished)
+    public RunAutomationStep(string? scriptPath, string? scriptArguments, bool runSilently, bool waitUntilFinished)
     {
         ScriptPath = scriptPath;
         ScriptArguments = scriptArguments;
@@ -30,7 +30,7 @@ public class RunAutomationStep : IAutomationStep
         if (string.IsNullOrWhiteSpace(ScriptPath))
             return;
 
-        var (_, output) = await CMD.RunAsync(ScriptPath, ScriptArguments ?? string.Empty, RunSilently ?? true, WaitUntilFinished ?? true, environment.Dictionary).ConfigureAwait(false);
+        var (_, output) = await CMD.RunAsync(ScriptPath, ScriptArguments ?? string.Empty, RunSilently, WaitUntilFinished, environment.Dictionary).ConfigureAwait(false);
         context.LastRunOutput = output.TrimEnd();
     }
 

--- a/LenovoLegionToolkit.Lib.Automation/Steps/RunAutomationStep.cs
+++ b/LenovoLegionToolkit.Lib.Automation/Steps/RunAutomationStep.cs
@@ -10,11 +10,17 @@ public class RunAutomationStep : IAutomationStep
 
     public string? ScriptArguments { get; }
 
+    public bool? RunSilently { get; }
+
+    public bool? WaitUntilFinished { get; }
+
     [JsonConstructor]
-    public RunAutomationStep(string? scriptPath, string? scriptArguments)
+    public RunAutomationStep(string? scriptPath, string? scriptArguments, bool? runSilently, bool? waitUntilFinished)
     {
         ScriptPath = scriptPath;
         ScriptArguments = scriptArguments;
+        RunSilently = runSilently;
+        WaitUntilFinished = waitUntilFinished;
     }
 
     public Task<bool> IsSupportedAsync() => Task.FromResult(true);
@@ -24,9 +30,9 @@ public class RunAutomationStep : IAutomationStep
         if (string.IsNullOrWhiteSpace(ScriptPath))
             return;
 
-        var (_, output) = await CMD.RunAsync(ScriptPath, ScriptArguments ?? string.Empty, environment: environment.Dictionary).ConfigureAwait(false);
+        var (_, output) = await CMD.RunAsync(ScriptPath, ScriptArguments ?? string.Empty, RunSilently ?? true, WaitUntilFinished ?? true, environment.Dictionary).ConfigureAwait(false);
         context.LastRunOutput = output.TrimEnd();
     }
 
-    IAutomationStep IAutomationStep.DeepCopy() => new RunAutomationStep(ScriptPath, ScriptArguments);
+    IAutomationStep IAutomationStep.DeepCopy() => new RunAutomationStep(ScriptPath, ScriptArguments, RunSilently, WaitUntilFinished);
 }

--- a/LenovoLegionToolkit.Lib/System/CMD.cs
+++ b/LenovoLegionToolkit.Lib/System/CMD.cs
@@ -33,7 +33,7 @@ public static class CMD
         if (!waitForExit)
         {
             if (Log.Instance.IsTraceEnabled)
-                Log.Instance.Trace($"Ran [file={file}, argument={arguments}, waitForExit={waitForExit}, environment=[{(environment is null ? string.Empty : string.Join(",", environment))}]");
+                Log.Instance.Trace($"Ran [file={file}, argument={arguments}, createNoWindow={createNoWindow}, waitForExit={waitForExit}, environment=[{(environment is null ? string.Empty : string.Join(",", environment))}]");
 
             return (-1, string.Empty);
         }
@@ -41,10 +41,10 @@ public static class CMD
         await cmd.WaitForExitAsync().ConfigureAwait(false);
 
         var exitCode = cmd.ExitCode;
-        var output = await cmd.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+        var output = createNoWindow ? await cmd.StandardOutput.ReadToEndAsync().ConfigureAwait(false) : string.Empty;
 
         if (Log.Instance.IsTraceEnabled)
-            Log.Instance.Trace($"Ran [file={file}, argument={arguments}, waitForExit={waitForExit}, exitCode={exitCode} output={output}]");
+            Log.Instance.Trace($"Ran [file={file}, argument={arguments}, createNoWindow={createNoWindow}, waitForExit={waitForExit}, exitCode={exitCode} output={output}]");
 
         return (exitCode, output);
     }

--- a/LenovoLegionToolkit.Lib/System/CMD.cs
+++ b/LenovoLegionToolkit.Lib/System/CMD.cs
@@ -7,16 +7,17 @@ namespace LenovoLegionToolkit.Lib.System;
 
 public static class CMD
 {
-    public static async Task<(int, string)> RunAsync(string file, string arguments, bool waitForExit = true, Dictionary<string, string?>? environment = null)
+    public static async Task<(int, string)> RunAsync(string file, string arguments, bool createNoWindow = true, bool waitForExit = true, Dictionary<string, string?>? environment = null)
     {
         if (Log.Instance.IsTraceEnabled)
             Log.Instance.Trace($"Running... [file={file}, argument={arguments}]");
 
         var cmd = new Process();
         cmd.StartInfo.UseShellExecute = false;
-        cmd.StartInfo.CreateNoWindow = true;
-        cmd.StartInfo.RedirectStandardOutput = true;
-        cmd.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+        cmd.StartInfo.CreateNoWindow = createNoWindow;
+        cmd.StartInfo.RedirectStandardOutput = createNoWindow;
+        cmd.StartInfo.RedirectStandardError = createNoWindow;
+        cmd.StartInfo.WindowStyle = createNoWindow ? ProcessWindowStyle.Hidden : ProcessWindowStyle.Normal;
         cmd.StartInfo.FileName = file;
         if (!string.IsNullOrWhiteSpace(arguments))
             cmd.StartInfo.Arguments = arguments;

--- a/LenovoLegionToolkit.WPF/Controls/Automation/Steps/RunAutomationStepControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Automation/Steps/RunAutomationStepControl.cs
@@ -62,7 +62,7 @@ public class RunAutomationStepControl : AbstractAutomationStepControl<RunAutomat
         _scriptArguments.Width = newWidth;
     }
 
-    public override IAutomationStep CreateAutomationStep() => new RunAutomationStep(_scriptPath.Text, _scriptArguments.Text);
+    public override IAutomationStep CreateAutomationStep() => new RunAutomationStep(_scriptPath.Text, _scriptArguments.Text, _checkBoxProcessRunSilently.IsChecked, _checkBoxProcessWaitUntilFinished.IsChecked);
 
     protected override UIElement GetCustomControl()
     {
@@ -91,6 +91,8 @@ public class RunAutomationStepControl : AbstractAutomationStepControl<RunAutomat
     {
         _scriptPath.Text = AutomationStep.ScriptPath ?? string.Empty;
         _scriptArguments.Text = AutomationStep.ScriptArguments ?? string.Empty;
+        _checkBoxProcessRunSilently.IsChecked = AutomationStep.RunSilently ?? true;
+        _checkBoxProcessWaitUntilFinished.IsChecked = AutomationStep.WaitUntilFinished ?? true;
         return Task.CompletedTask;
     }
 }

--- a/LenovoLegionToolkit.WPF/Controls/Automation/Steps/RunAutomationStepControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Automation/Steps/RunAutomationStepControl.cs
@@ -27,13 +27,11 @@ public class RunAutomationStepControl : AbstractAutomationStepControl<RunAutomat
     private readonly CheckBox _checkBoxProcessRunSilently = new()
     {
         Content = Resource.RunAutomationStepControl_ProcessRunSilently,
-        IsChecked = true,
     };
 
     private readonly CheckBox _checkBoxProcessWaitUntilFinished = new()
     {
         Content = Resource.RunAutomationStepControl_ProcessWaitUntilFinished,
-        IsChecked = true,
     };
 
     private readonly StackPanel _stackPanel = new();
@@ -62,7 +60,7 @@ public class RunAutomationStepControl : AbstractAutomationStepControl<RunAutomat
         _scriptArguments.Width = newWidth;
     }
 
-    public override IAutomationStep CreateAutomationStep() => new RunAutomationStep(_scriptPath.Text, _scriptArguments.Text, _checkBoxProcessRunSilently.IsChecked, _checkBoxProcessWaitUntilFinished.IsChecked);
+    public override IAutomationStep CreateAutomationStep() => new RunAutomationStep(_scriptPath.Text, _scriptArguments.Text, _checkBoxProcessRunSilently.IsChecked ?? true, _checkBoxProcessWaitUntilFinished.IsChecked ?? true);
 
     protected override UIElement GetCustomControl()
     {
@@ -101,8 +99,8 @@ public class RunAutomationStepControl : AbstractAutomationStepControl<RunAutomat
     {
         _scriptPath.Text = AutomationStep.ScriptPath ?? string.Empty;
         _scriptArguments.Text = AutomationStep.ScriptArguments ?? string.Empty;
-        _checkBoxProcessRunSilently.IsChecked = AutomationStep.RunSilently ?? true;
-        _checkBoxProcessWaitUntilFinished.IsChecked = AutomationStep.WaitUntilFinished ?? true;
+        _checkBoxProcessRunSilently.IsChecked = AutomationStep.RunSilently;
+        _checkBoxProcessWaitUntilFinished.IsChecked = AutomationStep.WaitUntilFinished;
         return Task.CompletedTask;
     }
 }

--- a/LenovoLegionToolkit.WPF/Controls/Automation/Steps/RunAutomationStepControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Automation/Steps/RunAutomationStepControl.cs
@@ -24,6 +24,18 @@ public class RunAutomationStepControl : AbstractAutomationStepControl<RunAutomat
         Width = 300,
     };
 
+    private readonly CheckBox _checkBoxProcessRunSilently = new()
+    {
+        Content = Resource.RunAutomationStepControl_ProcessRunSilently,
+        IsChecked = true,
+    };
+
+    private readonly CheckBox _checkBoxProcessWaitUntilFinished = new()
+    {
+        Content = Resource.RunAutomationStepControl_ProcessWaitUntilFinished,
+        IsChecked = true,
+    };
+
     private readonly StackPanel _stackPanel = new();
 
     public RunAutomationStepControl(RunAutomationStep step) : base(step)
@@ -34,6 +46,8 @@ public class RunAutomationStepControl : AbstractAutomationStepControl<RunAutomat
 
         AutomationProperties.SetName(_scriptPath, Resource.RunAutomationStepControl_ExePath);
         AutomationProperties.SetName(_scriptArguments, Resource.RunAutomationStepControl_ExeArguments);
+        AutomationProperties.SetName(_checkBoxProcessRunSilently, Resource.RunAutomationStepControl_ProcessRunSilently);
+        AutomationProperties.SetName(_checkBoxProcessWaitUntilFinished, Resource.RunAutomationStepControl_ProcessWaitUntilFinished);
 
         SizeChanged += RunAutomationStepControl_SizeChanged;
     }
@@ -65,6 +79,8 @@ public class RunAutomationStepControl : AbstractAutomationStepControl<RunAutomat
 
         _stackPanel.Children.Add(_scriptPath);
         _stackPanel.Children.Add(_scriptArguments);
+        _stackPanel.Children.Add(_checkBoxProcessRunSilently);
+        _stackPanel.Children.Add(_checkBoxProcessWaitUntilFinished);
 
         return _stackPanel;
     }

--- a/LenovoLegionToolkit.WPF/Controls/Automation/Steps/RunAutomationStepControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Automation/Steps/RunAutomationStepControl.cs
@@ -76,6 +76,16 @@ public class RunAutomationStepControl : AbstractAutomationStepControl<RunAutomat
             if (_scriptArguments.Text != AutomationStep.ScriptArguments)
                 RaiseChanged();
         };
+        _checkBoxProcessRunSilently.Checked += (_, _) =>
+        {
+            if (_checkBoxProcessRunSilently.IsChecked != AutomationStep.RunSilently)
+                RaiseChanged();
+        };
+        _checkBoxProcessWaitUntilFinished.Checked += (_, _) =>
+        {
+            if (_checkBoxProcessWaitUntilFinished.IsChecked != AutomationStep.WaitUntilFinished)
+                RaiseChanged();
+        };
 
         _stackPanel.Children.Add(_scriptPath);
         _stackPanel.Children.Add(_scriptArguments);

--- a/LenovoLegionToolkit.WPF/Pages/AutomationPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/AutomationPage.xaml.cs
@@ -183,7 +183,7 @@ public partial class AutomationPage
             new RefreshRateAutomationStep(default),
             new ResolutionAutomationStep(default),
             new RGBKeyboardBacklightAutomationStep(default),
-            new RunAutomationStep(default, default, default, default),
+            new RunAutomationStep(default, default, true, true),
             new SpectrumKeyboardBacklightBrightnessAutomationStep(0),
             new SpectrumKeyboardBacklightProfileAutomationStep(1),
             new SpectrumKeyboardBacklightImportProfileAutomationStep(default),

--- a/LenovoLegionToolkit.WPF/Pages/AutomationPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/AutomationPage.xaml.cs
@@ -183,7 +183,7 @@ public partial class AutomationPage
             new RefreshRateAutomationStep(default),
             new ResolutionAutomationStep(default),
             new RGBKeyboardBacklightAutomationStep(default),
-            new RunAutomationStep(default, default),
+            new RunAutomationStep(default, default, default, default),
             new SpectrumKeyboardBacklightBrightnessAutomationStep(0),
             new SpectrumKeyboardBacklightProfileAutomationStep(1),
             new SpectrumKeyboardBacklightImportProfileAutomationStep(default),

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -4318,6 +4318,24 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Run silently.
+        /// </summary>
+        public static string RunAutomationStepControl_ProcessRunSilently {
+            get {
+                return ResourceManager.GetString("RunAutomationStepControl_ProcessRunSilently", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Wait until finished.
+        /// </summary>
+        public static string RunAutomationStepControl_ProcessWaitUntilFinished {
+            get {
+                return ResourceManager.GetString("RunAutomationStepControl_ProcessWaitUntilFinished", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Run.
         /// </summary>
         public static string RunAutomationStepControl_Title {

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -2043,9 +2043,15 @@ Supported formats are: {1}.</value>
     <value>Reset "On battery since" at startup</value>
   </data>
   <data name="TurnOffWiFiAutomationStepControl_Title" xml:space="preserve">
-	  <value>Turn off WiFi</value>
+    <value>Turn off WiFi</value>
   </data>
   <data name="TurnOnWiFiAutomationStepControl_Title" xml:space="preserve">
-	  <value>Turn on WiFi</value>
+    <value>Turn on WiFi</value>
+  </data>
+  <data name="RunAutomationStepControl_ProcessRunSilently" xml:space="preserve">
+    <value>Run silently</value>
+  </data>
+  <data name="RunAutomationStepControl_ProcessWaitUntilFinished" xml:space="preserve">
+    <value>Wait until finished</value>
   </data>
 </root>


### PR DESCRIPTION
Inspired by #1214 and should close #1216.

Add two check-boxes to `RunAutomationStepControl`, and allow users to decide if their program should be launched with no window, or if action should wait for the program until it finishes and exits.

![image](https://github.com/BartoszCichecki/LenovoLegionToolkit/assets/104905842/a7a3350e-698c-4172-a363-af95b1d1a13f)

Up till now the following problems may need to be solved:

1. ~~I changed the paraments list of `LenovoLegionToolkit.Lib.System.CMD.RunAsync`, added a new parament `createNoWindow` which ist set default to true.~~

    ~~I didn't check other places using this function. Although they should actually work well but **I'm not sure**. So plz review these other places and make sure they won't cause anything wrong.~~ Checked, shouldn't break anything.

```cs
public static async Task<(int, string)> RunAsync(string file, 
                                                 string arguments,
                                                 bool createNoWindow = true,
                                                 bool waitForExit = true,
                                                 Dictionary<string, string?>? environment = null)
```

2. ~~All program, executable, script started by `RunAutomationStep` will run in admin privileges cuz LLT itself runs under it. I'm not sure if we should also add a check-box to ask the user if they want to lower the privilege, and I don't know if it's possible neither.~~ Possible, but almost not able to plug into the current codes. It requires five new native APIs and new process needs to be started with `CreateProcessWithTokenW` API, which leads huge problems with env vars and async. (In one word, it works but don't work well) I'll just leave this idea alone and not add it into code.

3. ~~I've noticed that if I launch cmd with `RunSilently` unchecked and `WaitUntilFinished` checked, no matter what I've done in the cmd console, LLT always show that step is finished with errors. ~~I don't know if this thing is reproduciable on your device, because I cannot reproduce it with step debug.~~ This bug is reproduciable. The exception is `One or more errors occurred. (StandardOut has not been redirected or the process hasn't started yet.)`. I think it may because of the change of `stdout` & `stderr` redirection. But if `stdout` and `stderr` still keep redirected, outputs from program will not be print to console. Therefore I have currently no idea how to fix it (but I'm still trying to).~~ Should be solved with [4bcc78e](https://github.com/BartoszCichecki/LenovoLegionToolkit/pull/1217/commits/47cc78ec94704c20190a638f98844143b31abed9).

![image](https://github.com/BartoszCichecki/LenovoLegionToolkit/assets/104905842/435c7440-d2d0-453d-889f-c81b903a872c)

4. ~~Check or uncheck both of the check-boxes won't call out a `Save` button, and it seems that changes to the check-boxes won't be saved. I'm not sure how I can fix it for now.~~ Solved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced automation capabilities with options to run processes silently and wait until they are finished.
- **User Interface Updates**
	- Added new checkboxes in the automation settings for controlling process execution behavior.
- **Localization**
	- Updated and added localized strings for the new automation process control options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->