### PR TITLE
Allow an empty rename to revert Action Name

### DIFF
--- a/LenovoLegionToolkit.WPF/Pages/AutomationPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/AutomationPage.xaml.cs
@@ -319,9 +319,6 @@ public partial class AutomationPage
             name,
             allowEmpty: true);
 
-        if (string.IsNullOrEmpty(newName))
-            return;
-
         control.SetName(newName);
     }
 


### PR DESCRIPTION
Should fix #1220.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the renaming process in the automation feature by removing unnecessary checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->