### PR TITLE
Add missing GPU #2 FanTableType

### DIFF
--- a/LenovoLegionToolkit.Lib/Controllers/GodMode/GodModeControllerV2.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/GodMode/GodModeControllerV2.cs
@@ -316,13 +316,16 @@ public class GodModeControllerV2(
                     (1, 4) => FanTableType.CPU,
                     (1, 1) => FanTableType.CPUSensor,
                     (2, 5) => FanTableType.GPU,
+                    (3, 5) => FanTableType.GPU2,
                     _ => FanTableType.Unknown,
                 };
                 return new FanTableData(type, d.fanId, d.sensorId, d.fanTableData, d.sensorTableData);
             })
             .ToArray();
 
-        if (fanTableData.Length != 3)
+        var length = fanTableData.Where(ftd => ftd.Type != FanTableType.Unknown).Count();
+
+        if (fanTableData.Length != length)
         {
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace($"Bad fan table length: {string.Join(", ", fanTableData)}");
@@ -330,7 +333,7 @@ public class GodModeControllerV2(
             return null;
         }
 
-        if (fanTableData.Count(ftd => ftd.FanSpeeds.Length == 10) != 3)
+        if (fanTableData.Count(ftd => ftd.FanSpeeds.Length == 10) != length)
         {
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace($"Bad fan table fan speeds length: {string.Join(", ", fanTableData)}");
@@ -338,7 +341,7 @@ public class GodModeControllerV2(
             return null;
         }
 
-        if (fanTableData.Count(ftd => ftd.Temps.Length == 10) != 3)
+        if (fanTableData.Count(ftd => ftd.Temps.Length == 10) != length)
         {
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace($"Bad fan table temps length: {string.Join(", ", fanTableData)}");

--- a/LenovoLegionToolkit.Lib/Enums.cs
+++ b/LenovoLegionToolkit.Lib/Enums.cs
@@ -89,8 +89,9 @@ public enum FanTableType
 {
     Unknown,
     CPU,
+    CPUSensor,
     GPU,
-    CPUSensor
+    GPU2
 }
 
 public enum FlipToStartState

--- a/LenovoLegionToolkit.Lib/Structs.cs
+++ b/LenovoLegionToolkit.Lib/Structs.cs
@@ -116,8 +116,7 @@ public readonly struct FanTableData(FanTableType type, byte fanId, byte sensorId
         $" {nameof(FanId)}: {FanId}," +
         $" {nameof(SensorId)}: {SensorId}," +
         $" {nameof(FanSpeeds)}: [{string.Join(", ", FanSpeeds)}]," +
-        $" {nameof(Temps)}: [{string.Join(", ", Temps)}]," +
-        $" {nameof(Type)}: {Type}";
+        $" {nameof(Temps)}: [{string.Join(", ", Temps)}]";
 }
 
 public readonly struct FanTable

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -1976,6 +1976,15 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to GPU #2.
+        /// </summary>
+        public static string FanCurveControl_GPU2 {
+            get {
+                return ResourceManager.GetString("FanCurveControl_GPU2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Filter....
         /// </summary>
         public static string Filter {

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -616,6 +616,9 @@ Thanks in advance!</value>
   <data name="FanCurveControl_GPU" xml:space="preserve">
     <value>GPU</value>
   </data>
+  <data name="FanCurveControl_GPU2" xml:space="preserve">
+    <value>GPU #2</value>
+  </data>
   <data name="RPM" xml:space="preserve">
     <value>RPM</value>
   </data>


### PR DESCRIPTION
<!---
Important!

Please make yourself familiar with Contribution section in the README and CONTRIBUTING.md file to make sure that your pull request is compliant.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for a second GPU in fan control settings.

- **Improvements**
	- Updated fan table data processing for enhanced consistency.
	- Improved the handling of different fan table types in the UI.
	- Enhanced code readability and maintainability in fan curve control.

- **Bug Fixes**
	- Fixed an issue where `CPUSensor` was duplicated in fan table types, replacing it with `GPU2`.

- **Localization**
	- Added localization support for "GPU #2" in fan curve controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->