### PR TITLE
Get right install dir on custom installation

### DIFF
--- a/LenovoLegionToolkit.Lib/Utils/Folders.cs
+++ b/LenovoLegionToolkit.Lib/Utils/Folders.cs
@@ -9,10 +9,7 @@ public static class Folders
     {
         get
         {
-            var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            var folderPath = Path.Combine(appData, "Programs", "LenovoLegionToolkit");
-            Directory.CreateDirectory(folderPath);
-            return folderPath;
+            return AppDomain.CurrentDomain.SetupInformation.ApplicationBase ?? string.Empty;
         }
     }
 


### PR DESCRIPTION
Fixes #1368.

Use `AppDomain.CurrentDomain` property to get program path. Fixed path under `AppData` doesn't work on custom installation.

Besides, I think there's no need to create the program directory before getting it. The installation directory must exist otherwise llt shouldn't be there, therefore I removed the directory create line.