### PR TITLE
Check GPUController is started before getting GPU info

### DIFF
--- a/LenovoLegionToolkit.Lib/Controllers/GPUController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/GPUController.cs
@@ -25,6 +25,7 @@ public class GPUController
     private string? _performanceState;
 
     public event EventHandler<GPUStatus>? Refreshed;
+    public bool Started { get; private set; } = false;
 
     public bool IsSupported()
     {
@@ -72,6 +73,7 @@ public class GPUController
         _refreshCancellationTokenSource = new CancellationTokenSource();
         var token = _refreshCancellationTokenSource.Token;
         _refreshTask = Task.Run(() => RefreshLoopAsync(delay, interval, token), token);
+        Started = true;
     }
 
     public async Task StopAsync(bool waitForFinish = false)
@@ -102,6 +104,7 @@ public class GPUController
 
         _refreshCancellationTokenSource = null;
         _refreshTask = null;
+        Started = false;
 
         if (Log.Instance.IsTraceEnabled)
             Log.Instance.Trace($"Stopped");

--- a/LenovoLegionToolkit.Lib/Controllers/Sensors/AbstractSensorsController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/Sensors/AbstractSensorsController.cs
@@ -171,6 +171,9 @@ public abstract class AbstractSensorsController(GPUController gpuController) : I
 
     private async Task<GPUInfo> GetGPUInfoAsync()
     {
+        if (gpuController.IsSupported() && !gpuController.Started)
+            await gpuController.StartAsync();
+
         if (await gpuController.GetLastKnownStateAsync().ConfigureAwait(false) is GPUState.PoweredOff or GPUState.Unknown)
             return GPUInfo.Empty;
 

--- a/LenovoLegionToolkit.Lib/Controllers/Sensors/AbstractSensorsController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/Sensors/AbstractSensorsController.cs
@@ -171,7 +171,7 @@ public abstract class AbstractSensorsController(GPUController gpuController) : I
 
     private async Task<GPUInfo> GetGPUInfoAsync()
     {
-        if (gpuController.IsSupported() && !gpuController.Started)
+        if (gpuController.IsSupported())
             await gpuController.StartAsync();
 
         if (await gpuController.GetLastKnownStateAsync().ConfigureAwait(false) is GPUState.PoweredOff or GPUState.Unknown)


### PR DESCRIPTION
Closes: #1501.

Add a `Started` state to `GPUController`. Check the state before getting GPU info to make sure datas would be got successfully.