### PR TITLE
Upgrade upload-artifact workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
@@ -23,7 +23,7 @@ jobs:
     - name: Build
       run: .\make.bat
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: installer
         path: build_installer\LenovoLegionToolkitSetup.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
@@ -28,7 +28,7 @@ jobs:
         files: build_installer/LenovoLegionToolkitSetup.exe
         fail_on_unmatched_files: true
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: installer
         path: build_installer/LenovoLegionToolkitSetup.exe


### PR DESCRIPTION
Upgrade upload-artifact to v4 since v3 of the artifact actions have been deprecated since Jan 30th, 2025.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/