### PR TITLE
Quick Action as Automation Step

### DIFF
--- a/LenovoLegionToolkit.Lib.Automation/Steps/QuickActionAutomationStep.cs
+++ b/LenovoLegionToolkit.Lib.Automation/Steps/QuickActionAutomationStep.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LenovoLegionToolkit.Lib.Automation.Steps;
+
+public class QuickActionAutomationStep(Guid? pipelineId)
+    : IAutomationStep
+{
+    public Guid? PipelineId { get; } = pipelineId;
+
+    public Task<bool> IsSupportedAsync() => Task.FromResult(true);
+
+    public async Task RunAsync(AutomationContext context, AutomationEnvironment environment, CancellationToken token)
+    {
+        if (PipelineId is not null)
+        {
+            await IoCContainer.Resolve<AutomationProcessor>().RunNowAsync(PipelineId ?? Guid.Empty).ConfigureAwait(false);
+        }
+
+        return;
+    }
+
+    IAutomationStep IAutomationStep.DeepCopy() => new QuickActionAutomationStep(PipelineId);
+}

--- a/LenovoLegionToolkit.WPF/Controls/Automation/AutomationPipelineControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Automation/AutomationPipelineControl.cs
@@ -357,6 +357,7 @@ public class AutomationPipelineControl : UserControl
             PlaySoundAutomationStep s => new PlaySoundAutomationStepControl(s),
             PortsBacklightAutomationStep s => new PortsBacklightAutomationStepControl(s),
             PowerModeAutomationStep s => new PowerModeAutomationStepControl(s),
+            QuickActionAutomationStep s => new QuickActionAutomationStepControl(s),
             RefreshRateAutomationStep s => new RefreshRateAutomationStepControl(s),
             ResolutionAutomationStep s => new ResolutionAutomationStepControl(s),
             RGBKeyboardBacklightAutomationStep s => new RGBKeyboardBacklightAutomationStepControl(s),

--- a/LenovoLegionToolkit.WPF/Controls/Automation/Steps/QuickActionAutomationStepControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Automation/Steps/QuickActionAutomationStepControl.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using LenovoLegionToolkit.Lib;
+using LenovoLegionToolkit.Lib.Automation;
+using LenovoLegionToolkit.Lib.Automation.Steps;
+using LenovoLegionToolkit.WPF.Resources;
+using Wpf.Ui.Common;
+
+namespace LenovoLegionToolkit.WPF.Controls.Automation.Steps;
+
+public class QuickActionAutomationStepControl : AbstractAutomationStepControl<QuickActionAutomationStep>
+{
+    private readonly AutomationProcessor _processor = IoCContainer.Resolve<AutomationProcessor>();
+
+    private readonly ComboBox _comboBox = new()
+    {
+        MinWidth = 150
+    };
+
+    private readonly StackPanel _stackPanel = new();
+
+    private bool _isRefreshing = false;
+
+    public QuickActionAutomationStepControl(QuickActionAutomationStep step) : base(step)
+    {
+        Icon = SymbolRegular.Play24;
+        Title = Resource.QuickActionAutomationStepControl_Title;
+        Subtitle = Resource.QuickActionAutomationStepControl_Message;
+    }
+
+    public override IAutomationStep CreateAutomationStep() => new QuickActionAutomationStep(GetSelectedPipelineIdAsync().Result);
+
+    protected override UIElement? GetCustomControl()
+    {
+        _comboBox.SelectionChanged += async (_, _) =>
+        {
+            if (_isRefreshing)
+            {
+                return;
+            }
+
+            var selectedPipelineId = await GetSelectedPipelineIdAsync();
+            if (selectedPipelineId != AutomationStep.PipelineId)
+            {
+                RaiseChanged();
+            }
+        };
+
+        _stackPanel.Children.Add(_comboBox);
+
+        return _stackPanel;
+    }
+
+    protected override void OnFinishedLoading() { }
+
+    protected override async Task RefreshAsync()
+    {
+        _isRefreshing = true;
+
+        _comboBox.Items.Clear();
+
+        var index = 0;
+        var selectedIndex = -1;
+        var pipelines = await _processor.GetPipelinesAsync();
+        foreach (var pipeline in pipelines.Where(p => p.Trigger is null))
+        {
+            _comboBox.Items.Add(pipeline.Name);
+            if (pipeline.Id == AutomationStep.PipelineId)
+            {
+                selectedIndex = index;
+            }
+            index++;
+        }
+        _comboBox.SelectedIndex = selectedIndex;
+
+        _isRefreshing = false;
+        return;
+    }
+
+    private async Task<Guid?> GetSelectedPipelineIdAsync()
+    {
+        var value = (string)_comboBox.SelectedItem;
+        var pipelines = await _processor.GetPipelinesAsync();
+        var selectedPipeline = pipelines.Where(p => p.Trigger is null).FirstOrDefault(p => p.Name == value);
+        if (selectedPipeline is not null)
+        {
+            return selectedPipeline.Id;
+        }
+        return null;
+    }
+}

--- a/LenovoLegionToolkit.WPF/Pages/AutomationPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/AutomationPage.xaml.cs
@@ -134,7 +134,7 @@ public partial class AutomationPage
 
         foreach (var pipeline in pipelines.Where(p => p.Trigger is null))
         {
-            var control = GenerateControl(pipeline, _manualPipelinesStackPanel);
+            var control = GenerateControl(pipeline, _manualPipelinesStackPanel, false);
             _manualPipelinesStackPanel.Children.Add(control);
             initializedTasks.Add(control.InitializedTask);
         }
@@ -181,6 +181,7 @@ public partial class AutomationPage
             new PlaySoundAutomationStep(default),
             new PortsBacklightAutomationStep(default),
             new PowerModeAutomationStep(default),
+            new QuickActionAutomationStep(default),
             new RefreshRateAutomationStep(default),
             new ResolutionAutomationStep(default),
             new RGBKeyboardBacklightAutomationStep(default),
@@ -208,9 +209,15 @@ public partial class AutomationPage
         return [.. steps];
     }
 
-    private AutomationPipelineControl GenerateControl(AutomationPipeline pipeline, Panel stackPanel)
+    private AutomationPipelineControl GenerateControl(AutomationPipeline pipeline, Panel stackPanel, bool allowQuickActionAutomationStep = true)
     {
-        var control = new AutomationPipelineControl(pipeline, _supportedAutomationSteps);
+        var supportedSteps = _supportedAutomationSteps;
+        if (!allowQuickActionAutomationStep)
+        {
+            supportedSteps = Array.FindAll(supportedSteps, s => s is not QuickActionAutomationStep);
+        }
+
+        var control = new AutomationPipelineControl(pipeline, supportedSteps);
         control.MouseRightButtonUp += (_, e) =>
         {
             ShowPipelineContextMenu(control, stackPanel);
@@ -301,7 +308,7 @@ public partial class AutomationPage
             return;
 
         var pipeline = new AutomationPipeline(newName);
-        var control = GenerateControl(pipeline, _manualPipelinesStackPanel);
+        var control = GenerateControl(pipeline, _manualPipelinesStackPanel, false);
         _manualPipelinesStackPanel.Children.Insert(0, control);
 
         _noManualActionsText.Visibility = _manualPipelinesStackPanel.Children.Count < 1

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -2522,7 +2522,7 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Custom Mode settings will not be applied correctly when LegionZone or it&apos;s services are running..
+        ///   Looks up a localized string similar to Custom Mode settings will not be applied correctly when Legion Zone or its services are running..
         /// </summary>
         public static string GodModeSettingsWindow_LegionZoneWarning_Title {
             get {
@@ -2540,7 +2540,7 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Custom Mode settings will not be applied correctly when Lenovo Vantage or it&apos;s services are running..
+        ///   Looks up a localized string similar to Custom Mode settings will not be applied correctly when Lenovo Vantage or its services are running..
         /// </summary>
         public static string GodModeSettingsWindow_VantageWarning_Title {
             get {
@@ -4308,6 +4308,24 @@ namespace LenovoLegionToolkit.WPF.Resources {
         public static string PowerPlansWindow_AoAcWarning_Title {
             get {
                 return ResourceManager.GetString("PowerPlansWindow_AoAcWarning_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run a saved quick action..
+        /// </summary>
+        public static string QuickActionAutomationStepControl_Message {
+            get {
+                return ResourceManager.GetString("QuickActionAutomationStepControl_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Quick Action.
+        /// </summary>
+        public static string QuickActionAutomationStepControl_Title {
+            get {
+                return ResourceManager.GetString("QuickActionAutomationStepControl_Title", resourceCulture);
             }
         }
         

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -2216,21 +2216,27 @@ Supported formats are: {1}.</value>
     <value>Automatically check for updates</value>
   </data>
   <data name="PackagesPage_UpdateCatalogNotFound_Title" xml:space="preserve">
-	  <value>Update catalog not found</value>
+    <value>Update catalog not found</value>
   </data>
   <data name="PackagesPage_UpdateCatalogNotFound_Message" xml:space="preserve">
-	  <value>Try getting updates from the other source.</value>
+    <value>Try getting updates from the other source.</value>
   </data>
   <data name="PackagesPage_Error_Title" xml:space="preserve">
-	  <value>Something went wrong</value>
+    <value>Something went wrong</value>
   </data>
   <data name="PackagesPage_Error_CheckInternet_Message" xml:space="preserve">
-	  <value>Check if your internet connection is up and running.</value>
+    <value>Check if your internet connection is up and running.</value>
   </data>
   <data name="PlaySoundAutomationStepControl_Title" xml:space="preserve">
-	  <value>Play sound</value>
+    <value>Play sound</value>
   </data>
   <data name="PlaySoundAutomationStepControl_Message" xml:space="preserve">
-	  <value>Common music formats like wav or mp3 are supported.</value>
+    <value>Common music formats like wav or mp3 are supported.</value>
+  </data>
+  <data name="QuickActionAutomationStepControl_Title" xml:space="preserve">
+    <value>Quick Action</value>
+  </data>
+  <data name="QuickActionAutomationStepControl_Message" xml:space="preserve">
+    <value>Run a saved quick action.</value>
   </data>
 </root>


### PR DESCRIPTION
Closes: #1574.

Add `QuickActionAutomationStep` to allow users to run a saved quick action pipeline within an automation pipeline. This automation step is only available in automation actions, because referencing a quick action in one another doesn't really make sense, and it may cause problem when we run one quick action in itself. I don't see a simple way to tell automation steps to remove a certain quick action from the list in current architecture, so I removed this feature.

TODO:

- [x] basic `QuickActionAutomationStep` feature
- [x] code cleanup
- [ ] ~~show warning when removing a quick action which is referenced by other automation pipeline~~

Plus: after giving another thought, showing a warning msg when removing referenced quick actions is a bit too more complicated than this PR should be. I'll remove this plan for now, but if you think it's necessary, plz let me know and I'll give another try.