### PR TITLE
Notifications Always on Top (AoT)

### DIFF
--- a/LenovoLegionToolkit.Lib/NativeMethods.txt
+++ b/LenovoLegionToolkit.Lib/NativeMethods.txt
@@ -210,4 +210,17 @@ WlanRegisterNotification
 
 MONITORINFOF_PRIMARY
 
+AC_SRC_ALPHA
+AC_SRC_OVER
+CreateCompatibleDC
+DeleteDC
+DeleteObject
+GetDC
+GetWindowRect
+ReleaseDC
+SelectObject
 SetWindowPos
+ShowWindow
+UpdateLayeredWindow
+WINDOW_STYLE
+WINDOW_EX_STYLE

--- a/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
@@ -36,6 +36,7 @@ public class ApplicationSettings : AbstractSettings<ApplicationSettings.Applicat
         public bool DontShowNotifications { get; set; }
         public NotificationPosition NotificationPosition { get; set; } = NotificationPosition.BottomCenter;
         public NotificationDuration NotificationDuration { get; set; } = NotificationDuration.Normal;
+        public bool NotificationAlwaysOnTop { get; set; }
         public bool NotificationOnAllScreens { get; set; }
         public Notifications Notifications { get; set; } = new();
         public TemperatureUnit TemperatureUnit { get; set; }

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -3516,6 +3516,25 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Always put notification at the top.
+        ///It won&apos;t affect other full screen windows, but you will not be able to click on the notifications..
+        /// </summary>
+        public static string NotificationsSettingsWindow_NotificationAlwaysOnTop_Message {
+            get {
+                return ResourceManager.GetString("NotificationsSettingsWindow_NotificationAlwaysOnTop_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Notification always on top.
+        /// </summary>
+        public static string NotificationsSettingsWindow_NotificationAlwaysOnTop_Title {
+            get {
+                return ResourceManager.GetString("NotificationsSettingsWindow_NotificationAlwaysOnTop_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Duration.
         /// </summary>
         public static string NotificationsSettingsWindow_NotificationDuration_Title {

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -2245,4 +2245,11 @@ Supported formats are: {1}.</value>
   <data name="QuickActionAutomationStepControl_Message" xml:space="preserve">
     <value>Run a saved quick action.</value>
   </data>
+  <data name="NotificationsSettingsWindow_NotificationAlwaysOnTop_Title" xml:space="preserve">
+    <value>Notification always on top</value>
+  </data>
+  <data name="NotificationsSettingsWindow_NotificationAlwaysOnTop_Message" xml:space="preserve">
+    <value>Always put notification at the top.
+It won't affect other full screen windows, but you will not be able to click on the notifications.</value>
+  </data>
 </root>

--- a/LenovoLegionToolkit.WPF/Utils/NotificationsManager.cs
+++ b/LenovoLegionToolkit.WPF/Utils/NotificationsManager.cs
@@ -233,7 +233,7 @@ public class NotificationsManager
         if (_windows.Count != 0)
         {
             foreach (var window in _windows)
-                window?.Close();
+                window?.Close(true);
 
             _windows.Clear();
         }

--- a/LenovoLegionToolkit.WPF/Utils/NotificationsManager.cs
+++ b/LenovoLegionToolkit.WPF/Utils/NotificationsManager.cs
@@ -23,7 +23,7 @@ public class NotificationsManager
 
     private readonly ApplicationSettings _settings;
 
-    private List<NotificationWindow?> _windows = [];
+    private List<INotificationWindow?> _windows = [];
 
     public NotificationsManager(ApplicationSettings settings)
     {
@@ -233,13 +233,8 @@ public class NotificationsManager
         if (_windows.Count != 0)
         {
             foreach (var window in _windows)
-            {
-                if (window is not null)
-                {
-                    window.WindowStyle = WindowStyle.None;
-                    window.Close();
-                }
-            }
+                window?.Close();
+
             _windows.Clear();
         }
 

--- a/LenovoLegionToolkit.WPF/Utils/NotificationsManager.cs
+++ b/LenovoLegionToolkit.WPF/Utils/NotificationsManager.cs
@@ -47,7 +47,7 @@ public class NotificationsManager
                 return;
             }
 
-            if (FullscreenHelper.IsAnyApplicationFullscreen())
+            if (FullscreenHelper.IsAnyApplicationFullscreen() && !_settings.Store.NotificationAlwaysOnTop)
             {
                 if (Log.Instance.IsTraceEnabled)
                     Log.Instance.Trace($"Some application is in fullscreen.");
@@ -244,6 +244,50 @@ public class NotificationsManager
             foreach (var screen in ScreenHelper.Screens)
             {
                 var nw = new NotificationWindow(symbol, overlaySymbol, symbolTransform, text, clickAction, screen, _settings.Store.NotificationPosition) { Owner = mainWindow };
+                if (_settings.Store.NotificationAlwaysOnTop)
+                {
+                    var bitmap = nw.GetBitmapView();
+                    var nwaot = new NotificationAoTWindow(bitmap, screen, _settings.Store.NotificationPosition);
+                    nwaot.Show(_settings.Store.NotificationDuration switch
+                    {
+                        NotificationDuration.Short => 500,
+                        NotificationDuration.Long => 2500,
+                        NotificationDuration.Normal => 1000,
+                        _ => throw new ArgumentException(nameof(_settings.Store.NotificationDuration))
+                    });
+                    _windows.Add(nwaot);
+                }
+                else
+                {
+                    nw.Show(_settings.Store.NotificationDuration switch
+                    {
+                        NotificationDuration.Short => 500,
+                        NotificationDuration.Long => 2500,
+                        NotificationDuration.Normal => 1000,
+                        _ => throw new ArgumentException(nameof(_settings.Store.NotificationDuration))
+                    });
+                    _windows.Add(nw);
+                }
+            }
+        }
+        else
+        {
+            var nw = new NotificationWindow(symbol, overlaySymbol, symbolTransform, text, clickAction, ScreenHelper.PrimaryScreen, _settings.Store.NotificationPosition) { Owner = mainWindow };
+            if (_settings.Store.NotificationAlwaysOnTop)
+            {
+                var bitmap = nw.GetBitmapView();
+                var nwaot = new NotificationAoTWindow(bitmap, ScreenHelper.PrimaryScreen, _settings.Store.NotificationPosition);
+                nwaot.Show(_settings.Store.NotificationDuration switch
+                {
+                    NotificationDuration.Short => 500,
+                    NotificationDuration.Long => 2500,
+                    NotificationDuration.Normal => 1000,
+                    _ => throw new ArgumentException(nameof(_settings.Store.NotificationDuration))
+                });
+                _windows.Add(nwaot);
+            }
+            else
+            {
                 nw.Show(_settings.Store.NotificationDuration switch
                 {
                     NotificationDuration.Short => 500,
@@ -253,18 +297,6 @@ public class NotificationsManager
                 });
                 _windows.Add(nw);
             }
-        }
-        else
-        {
-            var nw = new NotificationWindow(symbol, overlaySymbol, symbolTransform, text, clickAction, ScreenHelper.PrimaryScreen, _settings.Store.NotificationPosition) { Owner = mainWindow };
-            nw.Show(_settings.Store.NotificationDuration switch
-            {
-                NotificationDuration.Short => 500,
-                NotificationDuration.Long => 2500,
-                NotificationDuration.Normal => 1000,
-                _ => throw new ArgumentException(nameof(_settings.Store.NotificationDuration))
-            });
-            _windows.Add(nw);
         }
     }
 

--- a/LenovoLegionToolkit.WPF/Windows/Settings/NotificationsSettingsWindow.xaml
+++ b/LenovoLegionToolkit.WPF/Windows/Settings/NotificationsSettingsWindow.xaml
@@ -64,6 +64,17 @@
 
                 <custom:CardControl Margin="0,0,0,8">
                     <custom:CardControl.Header>
+                        <controls:CardHeaderControl Title="{x:Static resources:Resource.NotificationsSettingsWindow_NotificationAlwaysOnTop_Title}" Subtitle="{x:Static resources:Resource.NotificationsSettingsWindow_NotificationAlwaysOnTop_Message}" />
+                    </custom:CardControl.Header>
+                    <wpfui:ToggleSwitch
+                        x:Name="_notificationAlwaysOnTopToggle"
+                        Margin="0,0,0,8"
+                        AutomationProperties.Name="{x:Static resources:Resource.NotificationsSettingsWindow_NotificationAlwaysOnTop_Title}"
+                        Click="NotificationAlwaysOnTopToggle_Click" />
+                </custom:CardControl>
+                
+                <custom:CardControl Margin="0,0,0,8">
+                    <custom:CardControl.Header>
                         <controls:CardHeaderControl Title="{x:Static resources:Resource.NotificationsSettingsWindow_NotificationOnAllScreens_Title}" Subtitle="{x:Static resources:Resource.NotificationsSettingsWindow_NotificationOnAllScreens_Message}" />
                     </custom:CardControl.Header>
                     <wpfui:ToggleSwitch

--- a/LenovoLegionToolkit.WPF/Windows/Settings/NotificationsSettingsWindow.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Settings/NotificationsSettingsWindow.xaml.cs
@@ -37,6 +37,7 @@ public partial class NotificationsSettingsWindow
         InitializeComponent();
 
         _dontShowNotificationsToggle.IsChecked = _settings.Store.DontShowNotifications;
+        _notificationAlwaysOnTopToggle.IsChecked = _settings.Store.NotificationAlwaysOnTop;
         _notificationOnAllScreensToggle.IsChecked = _settings.Store.NotificationOnAllScreens;
 
         _notificationPositionComboBox.SetItems(Enum.GetValues<NotificationPosition>(), _settings.Store.NotificationPosition, v => v.GetDisplayName());

--- a/LenovoLegionToolkit.WPF/Windows/Settings/NotificationsSettingsWindow.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Settings/NotificationsSettingsWindow.xaml.cs
@@ -78,6 +78,16 @@ public partial class NotificationsSettingsWindow
         RefreshCards();
     }
 
+    private void NotificationAlwaysOnTopToggle_Click(object sender, RoutedEventArgs e)
+    {
+        var state = _notificationAlwaysOnTopToggle.IsChecked;
+        if (state is null)
+            return;
+
+        _settings.Store.NotificationAlwaysOnTop = state.Value;
+        _settings.SynchronizeStore();
+    }
+
     private void NotificationOnAllScreensToggle_Click(object sender, RoutedEventArgs e)
     {
         var state = _notificationOnAllScreensToggle.IsChecked;

--- a/LenovoLegionToolkit.WPF/Windows/Utils/INotificationWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/INotificationWindow.cs
@@ -3,5 +3,5 @@
 public interface INotificationWindow
 {
     public void Show(int closeAfter);
-    public void Close();
+    public void Close(bool immediate);
 }

--- a/LenovoLegionToolkit.WPF/Windows/Utils/INotificationWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/INotificationWindow.cs
@@ -1,0 +1,7 @@
+﻿namespace LenovoLegionToolkit.WPF.Windows.Utils;
+
+public interface INotificationWindow
+{
+    public void Show(int closeAfter);
+    public void Close();
+}

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NativeLayeredWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NativeLayeredWindow.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace LenovoLegionToolkit.WPF.Windows.Utils;
+
+public class NativeLayeredWindow : NativeWindow, IDisposable
+{
+    private byte _alpha = 250;
+    private bool _disposed;
+    private Size _size = new(350, 50);
+    private Point _pos = new(50, 50);
+
+    public Size Size
+    {
+        get { return _size; }
+        set
+        {
+            if (Handle != nint.Zero)
+            {
+                UpdateWindowSizePosition(_pos.X, _pos.Y, value.Width, value.Height);
+                RECT rect = new();
+                PInvoke.GetWindowRect((HWND)Handle, out rect);
+                _size = new(rect.Width, rect.Height);
+                UpdateLayeredWindow();
+            }
+            else
+            {
+                _size = value;
+            }
+        }
+    }
+
+    public int Width
+    {
+        get { return _size.Width; }
+        set { _size.Width = value; }
+    }
+
+    public int Height
+    {
+        get { return _size.Height; }
+        set { _size.Height = value; }
+    }
+
+    public Point Position
+    {
+        get { return _pos; }
+        set
+        {
+            if (Handle != nint.Zero)
+            {
+                UpdateWindowSizePosition(value.X, value.Y, _size.Width, _size.Height);
+                RECT rect = new();
+                PInvoke.GetWindowRect((HWND)Handle, out rect);
+                _pos = new(rect.left, rect.top);
+                UpdateLayeredWindow();
+            }
+            else
+            {
+                _pos = value;
+            }
+        }
+    }
+
+    public void Show()
+    {
+        if (Handle == nint.Zero)
+            CreateLayeredWindow();
+
+        PInvoke.ShowWindow((HWND)Handle, SHOW_WINDOW_CMD.SW_SHOWNOACTIVATE);
+    }
+
+    public void Hide()
+    {
+        if (Handle == nint.Zero)
+            return;
+
+        PInvoke.ShowWindow((HWND)Handle, SHOW_WINDOW_CMD.SW_HIDE);
+    }
+
+    public void Close()
+    {
+        Hide();
+        Dispose();
+    }
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            DestroyHandle();
+            _disposed = true;
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private void CreateLayeredWindow()
+    {
+        var style = WINDOW_STYLE.WS_POPUP;
+        var exStyle = WINDOW_EX_STYLE.WS_EX_TOPMOST |
+            WINDOW_EX_STYLE.WS_EX_TOOLWINDOW |
+            WINDOW_EX_STYLE.WS_EX_LAYERED |
+            WINDOW_EX_STYLE.WS_EX_NOACTIVATE |
+            WINDOW_EX_STYLE.WS_EX_TRANSPARENT;
+        CreateParams cp = new()
+        {
+            Caption = "LenovoLegionToolkit-NativeLayeredWindow",
+            X = Position.X,
+            Y = Position.Y,
+            Height = Size.Height,
+            Width = Size.Width,
+            Parent = nint.Zero,
+            Style = (int)style,
+            ExStyle = (int)exStyle
+        };
+        CreateHandle(cp);
+        UpdateLayeredWindow();
+    }
+
+    protected virtual void Paint(PaintEventArgs e) { }
+
+    private void UpdateLayeredWindow()
+    {
+        Bitmap bitmap = new(Size.Width, Size.Height, PixelFormat.Format32bppArgb);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        Rectangle cr = new(0, 0, Size.Width, Size.Height);
+        Paint(new(graphics, cr));
+        var hdcDst = PInvoke.GetDC(HWND.Null);
+        var hdcSrc = PInvoke.CreateCompatibleDC(hdcDst);
+        var hbitmap = bitmap.GetHbitmap(Color.FromArgb(0));
+        var hObject = SelectObject(hdcSrc, hbitmap);
+        SIZE size = new(Size.Width, Size.Height);
+        Point ptDst = new(Position.X, Position.Y);
+        Point ptSrc = new(0, 0);
+        COLORREF colorRef = new(0); // rgbBlack
+        BLENDFUNCTION blend = new()
+        {
+            BlendOp = (byte)PInvoke.AC_SRC_OVER,
+            BlendFlags = 0,
+            SourceConstantAlpha = _alpha,
+            AlphaFormat = (byte)PInvoke.AC_SRC_ALPHA
+        };
+        PInvoke.UpdateLayeredWindow((HWND)Handle, hdcDst, ptDst, size, hdcSrc, ptSrc, colorRef, blend, UPDATE_LAYERED_WINDOW_FLAGS.ULW_ALPHA);
+        SelectObject(hdcSrc, hObject);
+        _ = PInvoke.ReleaseDC(HWND.Null, hdcDst);
+        PInvoke.DeleteObject((HGDIOBJ)hbitmap);
+        PInvoke.DeleteDC(hdcSrc);
+    }
+
+    private void UpdateWindowSizePosition(int x, int y, int width, int height)
+    {
+        if (Position.X != x || Position.Y != y || Size.Width != width || Size.Height != height)
+        {
+            if (Handle != nint.Zero)
+            {
+                SET_WINDOW_POS_FLAGS flags = 0;
+                if (Position.X == x && Position.Y == y)
+                {
+                    flags |= SET_WINDOW_POS_FLAGS.SWP_NOMOVE;
+                }
+                if (Size.Width == width && Size.Height == height)
+                {
+                    flags |= SET_WINDOW_POS_FLAGS.SWP_NOSIZE;
+                }
+                PInvoke.SetWindowPos((HWND)Handle, HWND.Null, x, y, width, height, flags);
+            }
+            else
+            {
+                Size = new(width, height);
+                Position = new(x, y);
+            }
+        }
+    }
+
+    [DllImport("gdi32.dll", CharSet = CharSet.Auto)]
+    private static extern nint SelectObject(nint hDC, nint hObject);
+}

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NativeLayeredWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NativeLayeredWindow.cs
@@ -12,7 +12,6 @@ namespace LenovoLegionToolkit.WPF.Windows.Utils;
 
 public class NativeLayeredWindow : NativeWindow, IDisposable
 {
-    private byte _alpha = 250;
     private bool _disposed;
     private Size _size = new(350, 50);
     private Point _pos = new(50, 50);
@@ -25,8 +24,7 @@ public class NativeLayeredWindow : NativeWindow, IDisposable
             if (Handle != nint.Zero)
             {
                 UpdateWindowSizePosition(_pos.X, _pos.Y, value.Width, value.Height);
-                RECT rect = new();
-                PInvoke.GetWindowRect((HWND)Handle, out rect);
+                PInvoke.GetWindowRect((HWND)Handle, out RECT rect);
                 _size = new(rect.Width, rect.Height);
                 UpdateLayeredWindow();
             }
@@ -57,8 +55,7 @@ public class NativeLayeredWindow : NativeWindow, IDisposable
             if (Handle != nint.Zero)
             {
                 UpdateWindowSizePosition(value.X, value.Y, _size.Width, _size.Height);
-                RECT rect = new();
-                PInvoke.GetWindowRect((HWND)Handle, out rect);
+                PInvoke.GetWindowRect((HWND)Handle, out RECT rect);
                 _pos = new(rect.left, rect.top);
                 UpdateLayeredWindow();
             }
@@ -144,7 +141,7 @@ public class NativeLayeredWindow : NativeWindow, IDisposable
         {
             BlendOp = (byte)PInvoke.AC_SRC_OVER,
             BlendFlags = 0,
-            SourceConstantAlpha = _alpha,
+            SourceConstantAlpha = 255,
             AlphaFormat = (byte)PInvoke.AC_SRC_ALPHA
         };
         PInvoke.UpdateLayeredWindow((HWND)Handle, hdcDst, ptDst, size, hdcSrc, ptSrc, colorRef, blend, UPDATE_LAYERED_WINDOW_FLAGS.ULW_ALPHA);

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NativeLayeredWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NativeLayeredWindow.cs
@@ -12,7 +12,7 @@ namespace LenovoLegionToolkit.WPF.Windows.Utils;
 
 public class NativeLayeredWindow : NativeWindow, IDisposable
 {
-    private const int AnimationDurationMs = 100;
+    private const int AnimationDurationMs = 70;
     private const int AnimationIntevalMs = 10;
     private readonly Timer _animationTimer = new() { Interval = AnimationIntevalMs };
 

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationAoTWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationAoTWindow.cs
@@ -6,7 +6,7 @@ using LenovoLegionToolkit.Lib;
 
 namespace LenovoLegionToolkit.WPF.Windows.Utils;
 
-public class NotificationAoTWindow(ScreenInfo screenInfo, NotificationPosition position) : NativeLayeredWindow
+public class NotificationAoTWindow(ScreenInfo screenInfo, NotificationPosition position) : NativeLayeredWindow, INotificationWindow
 {
     private readonly ScreenInfo _screenInfo = screenInfo;
     private readonly NotificationPosition _position = position;

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationAoTWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationAoTWindow.cs
@@ -1,0 +1,102 @@
+﻿using LenovoLegionToolkit.Lib;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Forms;
+
+namespace LenovoLegionToolkit.WPF.Windows.Utils;
+
+public class NotificationAoTWindow(ScreenInfo screenInfo, NotificationPosition position) : NativeLayeredWindow
+{
+    private readonly ScreenInfo _screenInfo = screenInfo;
+    private readonly NotificationPosition _position = position;
+
+    private Bitmap? _bitmap;
+
+    public void SetBitmap(Bitmap bitmap)
+    {
+        _bitmap = bitmap;
+        UpdatePosition();
+    }
+
+    public void Show(int closeAfter)
+    {
+        Show();
+        Task.Delay(closeAfter).ContinueWith(_ =>
+        {
+            Close();
+        }, TaskScheduler.FromCurrentSynchronizationContext());
+    }
+
+    protected override void Paint(PaintEventArgs e)
+    {
+        if (_bitmap is not null)
+            e.Graphics.DrawImage(_bitmap, new Rectangle(0, 0, _bitmap.Width, _bitmap.Height));
+    }
+
+    private void UpdatePosition()
+    {
+        if (_bitmap is null)
+            return;
+
+        var multiplierX = _screenInfo.DpiX / 96d;
+        var multiplierY = _screenInfo.DpiY / 96d;
+        var wa = _screenInfo.WorkArea;
+        Rect workArea = new(wa.Left, wa.Top, wa.Width * multiplierX, wa.Height * multiplierY);
+
+        Size = new(_bitmap.Width, _bitmap.Height);
+
+        const int margin = 16;
+        var marginX = margin * multiplierX;
+        var marginY = margin * multiplierY;
+
+        double left = 0;
+        double top = 0;
+
+        switch (_position)
+        {
+            case NotificationPosition.BottomRight:
+                left = workArea.Right - Width - marginX;
+                top = workArea.Bottom - Height - marginY;
+                break;
+            case NotificationPosition.BottomCenter:
+                left = workArea.Left + (workArea.Width - Width) / 2;
+                top = workArea.Bottom - Height - marginY;
+                break;
+            case NotificationPosition.BottomLeft:
+                left = workArea.Left + marginX;
+                top = workArea.Bottom - Height - marginY;
+                break;
+            case NotificationPosition.CenterLeft:
+                left = workArea.Left + marginX;
+                top = workArea.Top + (workArea.Height - Height) / 2;
+                break;
+            case NotificationPosition.TopLeft:
+                left = workArea.Left + marginX;
+                top = workArea.Top + marginY;
+                break;
+            case NotificationPosition.TopCenter:
+                left = workArea.Left + (workArea.Width - Width) / 2;
+                top = workArea.Top + marginY;
+                break;
+            case NotificationPosition.TopRight:
+                left = workArea.Right - Width - marginX;
+                top = workArea.Top + marginY;
+                break;
+            case NotificationPosition.CenterRight:
+                left = workArea.Right - Width - marginX;
+                top = workArea.Top + (workArea.Height - Height) / 2;
+                break;
+            case NotificationPosition.Center:
+                left = workArea.Left + (workArea.Width - Width) / 2;
+                top = workArea.Top + (workArea.Height - Height) / 2;
+                break;
+        }
+
+        Position = new((int)left, (int)top);
+    }
+}

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationAoTWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationAoTWindow.cs
@@ -6,16 +6,17 @@ using LenovoLegionToolkit.Lib;
 
 namespace LenovoLegionToolkit.WPF.Windows.Utils;
 
-public class NotificationAoTWindow(ScreenInfo screenInfo, NotificationPosition position) : NativeLayeredWindow, INotificationWindow
+public class NotificationAoTWindow : NativeLayeredWindow, INotificationWindow
 {
-    private readonly ScreenInfo _screenInfo = screenInfo;
-    private readonly NotificationPosition _position = position;
+    private readonly Bitmap _bitmap;
+    private readonly ScreenInfo _screenInfo;
+    private readonly NotificationPosition _pos;
 
-    private Bitmap? _bitmap;
-
-    public void SetBitmap(Bitmap bitmap)
+    public NotificationAoTWindow(Bitmap bitmap, ScreenInfo screenInfo, NotificationPosition position)
     {
         _bitmap = bitmap;
+        _screenInfo = screenInfo;
+        _pos = position;
         UpdatePosition();
     }
 
@@ -30,15 +31,11 @@ public class NotificationAoTWindow(ScreenInfo screenInfo, NotificationPosition p
 
     protected override void Paint(PaintEventArgs e)
     {
-        if (_bitmap is not null)
-            e.Graphics.DrawImage(_bitmap, new Rectangle(0, 0, _bitmap.Width, _bitmap.Height));
+        e.Graphics.DrawImage(_bitmap, new Rectangle(0, 0, _bitmap.Width, _bitmap.Height));
     }
 
     private void UpdatePosition()
     {
-        if (_bitmap is null)
-            return;
-
         var multiplierX = _screenInfo.DpiX / 96d;
         var multiplierY = _screenInfo.DpiY / 96d;
         var wa = _screenInfo.WorkArea;
@@ -53,7 +50,7 @@ public class NotificationAoTWindow(ScreenInfo screenInfo, NotificationPosition p
         double left = 0;
         double top = 0;
 
-        switch (_position)
+        switch (_pos)
         {
             case NotificationPosition.BottomRight:
                 left = workArea.Right - Width - marginX;

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationAoTWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationAoTWindow.cs
@@ -1,12 +1,8 @@
-﻿using LenovoLegionToolkit.Lib;
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Text;
+﻿using System.Drawing;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
+using LenovoLegionToolkit.Lib;
 
 namespace LenovoLegionToolkit.WPF.Windows.Utils;
 

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationAoTWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationAoTWindow.cs
@@ -25,7 +25,7 @@ public class NotificationAoTWindow : NativeLayeredWindow, INotificationWindow
         Show();
         Task.Delay(closeAfter).ContinueWith(_ =>
         {
-            Close();
+            Close(false);
         }, TaskScheduler.FromCurrentSynchronizationContext());
     }
 

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
@@ -78,10 +78,10 @@ public class NotificationWindow : UiWindow, INotificationWindow
         }, TaskScheduler.FromCurrentSynchronizationContext());
     }
 
-    public new void Close()
+    public void Close(bool immediate)
     {
         WindowStyle = WindowStyle.None;
-        base.Close();
+        Close();
     }
 
     public Bitmap GetBitmapView()

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
@@ -106,22 +106,17 @@ public class NotificationWindow : UiWindow, INotificationWindow
         var resizedBitmap = new Bitmap(newWidth, newHeight);
         using var graphics = Graphics.FromImage(resizedBitmap);
         graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
+        graphics.SmoothingMode = SmoothingMode.AntiAlias;
 
-        var path = new GraphicsPath();
-        var rect = new Rectangle(0, 0, newWidth, newHeight);
-        const int diameter = 20;
-        path.AddArc(rect.X, rect.Y, diameter, diameter, 180, 90);
-        path.AddArc(rect.Right - diameter, rect.Y, diameter, diameter, 270, 90);
-        path.AddArc(rect.Right - diameter, rect.Bottom - diameter, diameter, diameter, 0, 90);
-        path.AddArc(rect.X, rect.Bottom - diameter, diameter, diameter, 90, 90);
-        path.CloseFigure();
+        var borderPath = GetRoundedRectanglePath(new(0, 0, newWidth, newHeight), 10);
+        var penPath = GetRoundedRectanglePath(new(1, 1, newWidth - 3, newHeight - 3), 10);
 
-        graphics.SetClip(path);
+        graphics.SetClip(borderPath);
         graphics.DrawImage(bitmap, 0, 0, newWidth, newHeight);
         graphics.ResetClip();
 
-        using var pen = new System.Drawing.Pen(System.Drawing.Color.FromArgb(64, 64, 64), 2);
-        graphics.DrawPath(pen, path);
+        using var pen = new System.Drawing.Pen(System.Drawing.Color.FromArgb(64, 64, 64), 3);
+        graphics.DrawPath(pen, penPath);
 
         return resizedBitmap;
     }
@@ -237,5 +232,17 @@ public class NotificationWindow : UiWindow, INotificationWindow
         symbolTransform?.Invoke(_symbolIcon);
 
         Content = _mainGrid;
+    }
+
+    private GraphicsPath GetRoundedRectanglePath(Rectangle rect, int radius)
+    {
+        var path = new GraphicsPath();
+        int diameter = radius * 2;
+        path.AddArc(rect.X, rect.Y, diameter, diameter, 180, 90);
+        path.AddArc(rect.Right - diameter, rect.Y, diameter, diameter, 270, 90);
+        path.AddArc(rect.Right - diameter, rect.Bottom - diameter, diameter, diameter, 0, 90);
+        path.AddArc(rect.X, rect.Bottom - diameter, diameter, diameter, 90, 90);
+        path.CloseFigure();
+        return path;
     }
 }

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
@@ -15,7 +15,7 @@ using Wpf.Ui.Controls;
 
 namespace LenovoLegionToolkit.WPF.Windows.Utils;
 
-public class NotificationWindow : UiWindow
+public class NotificationWindow : UiWindow, INotificationWindow
 {
     private readonly Grid _mainGrid = new()
     {
@@ -54,7 +54,7 @@ public class NotificationWindow : UiWindow
         SourceInitialized += (_, _) => InitializePosition(screenInfo.WorkArea, screenInfo.DpiX, screenInfo.DpiY, position);
         MouseDown += (_, _) =>
         {
-            Close();
+            base.Close();
             clickAction?.Invoke();
         };
     }
@@ -64,8 +64,14 @@ public class NotificationWindow : UiWindow
         Show();
         Task.Delay(closeAfter).ContinueWith(_ =>
         {
-            Close();
+            base.Close();
         }, TaskScheduler.FromCurrentSynchronizationContext());
+    }
+
+    public new void Close()
+    {
+        WindowStyle = WindowStyle.None;
+        base.Close();
     }
 
     private void InitializeStyle()

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
@@ -106,7 +106,22 @@ public class NotificationWindow : UiWindow, INotificationWindow
         var resizedBitmap = new Bitmap(newWidth, newHeight);
         using var graphics = Graphics.FromImage(resizedBitmap);
         graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
+
+        var path = new GraphicsPath();
+        var rect = new Rectangle(0, 0, newWidth, newHeight);
+        const int diameter = 40;
+        path.AddArc(rect.X, rect.Y, diameter, diameter, 180, 90);
+        path.AddArc(rect.Right - diameter, rect.Y, diameter, diameter, 270, 90);
+        path.AddArc(rect.Right - diameter, rect.Bottom - diameter, diameter, diameter, 0, 90);
+        path.AddArc(rect.X, rect.Bottom - diameter, diameter, diameter, 90, 90);
+        path.CloseFigure();
+
+        graphics.SetClip(path);
         graphics.DrawImage(bitmap, 0, 0, newWidth, newHeight);
+        graphics.ResetClip();
+
+        using var pen = new System.Drawing.Pen(System.Drawing.Color.Gray, 2);
+        graphics.DrawPath(pen, path);
 
         return resizedBitmap;
     }

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
@@ -1,9 +1,13 @@
 ﻿using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using LenovoLegionToolkit.Lib;
 using LenovoLegionToolkit.WPF.Utils;
 using Windows.Win32;
@@ -17,6 +21,8 @@ namespace LenovoLegionToolkit.WPF.Windows.Utils;
 
 public class NotificationWindow : UiWindow, INotificationWindow
 {
+    private readonly ScreenInfo _screenInfo;
+
     private readonly Grid _mainGrid = new()
     {
         ColumnDefinitions =
@@ -46,10 +52,14 @@ public class NotificationWindow : UiWindow, INotificationWindow
         VerticalContentAlignment = VerticalAlignment.Center,
     };
 
+    private bool _gettingBitMap;
+
     public NotificationWindow(SymbolRegular symbol, SymbolRegular? overlaySymbol, Action<SymbolIcon>? symbolTransform, string text, Action? clickAction, ScreenInfo screenInfo, NotificationPosition position)
     {
         InitializeStyle();
         InitializeContent(symbol, overlaySymbol, symbolTransform, text);
+
+        _screenInfo = screenInfo;
 
         SourceInitialized += (_, _) => InitializePosition(screenInfo.WorkArea, screenInfo.DpiX, screenInfo.DpiY, position);
         MouseDown += (_, _) =>
@@ -74,6 +84,33 @@ public class NotificationWindow : UiWindow, INotificationWindow
         base.Close();
     }
 
+    public Bitmap GetBitmapView()
+    {
+        _gettingBitMap = true;
+        Show();
+        Close();
+        _gettingBitMap = false;
+
+        RenderTargetBitmap rtb = new((int)Width, (int)Height, 96, 96, PixelFormats.Pbgra32);
+        rtb.Render(this);
+        var ms = new MemoryStream();
+        var encoder = new BmpBitmapEncoder();
+        encoder.Frames.Add(BitmapFrame.Create(rtb));
+        encoder.Save(ms);
+        using var bitmap = new Bitmap(ms);
+
+        var multiplierX = _screenInfo.DpiX / 96d;
+        var multiplierY = _screenInfo.DpiY / 96d;
+        var newWidth = (int)(bitmap.Width * multiplierX);
+        var newHeight = (int)(bitmap.Height * multiplierY);
+        var resizedBitmap = new Bitmap(newWidth, newHeight);
+        using var graphics = Graphics.FromImage(resizedBitmap);
+        graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
+        graphics.DrawImage(bitmap, 0, 0, newWidth, newHeight);
+
+        return resizedBitmap;
+    }
+
     private void InitializeStyle()
     {
         WindowStartupLocation = WindowStartupLocation.Manual;
@@ -92,7 +129,7 @@ public class NotificationWindow : UiWindow, INotificationWindow
 
     private void InitializePosition(Rect workArea, uint dpiX, uint dpiY, NotificationPosition position)
     {
-        _mainGrid.Measure(new Size(double.PositiveInfinity, 80));
+        _mainGrid.Measure(new System.Windows.Size(double.PositiveInfinity, 80));
 
         var multiplierX = dpiX / 96d;
         var multiplierY = dpiY / 96d;
@@ -100,54 +137,63 @@ public class NotificationWindow : UiWindow, INotificationWindow
 
         Width = MaxWidth = MinWidth = Math.Max(_mainGrid.DesiredSize.Width, 300);
         Height = MaxHeight = MinHeight = _mainGrid.DesiredSize.Height;
-        var nativeWidth = Width * multiplierX;
-        var nativeHeight = Height * multiplierY;
-
-        const int margin = 16;
-        var nativeMarginX = margin * multiplierX;
-        var nativeMarginY = margin * multiplierY;
 
         double nativeLeft = 0;
         double nativeTop = 0;
 
-        switch (position)
+        if (_gettingBitMap)
         {
-            case NotificationPosition.BottomRight:
-                nativeLeft = nativeWorkArea.Right - nativeWidth - nativeMarginX;
-                nativeTop = nativeWorkArea.Bottom - nativeHeight - nativeMarginY;
-                break;
-            case NotificationPosition.BottomCenter:
-                nativeLeft = nativeWorkArea.Left + (nativeWorkArea.Width - nativeWidth) / 2;
-                nativeTop = nativeWorkArea.Bottom - nativeHeight - nativeMarginY;
-                break;
-            case NotificationPosition.BottomLeft:
-                nativeLeft = nativeWorkArea.Left + nativeMarginX;
-                nativeTop = nativeWorkArea.Bottom - nativeHeight - nativeMarginY;
-                break;
-            case NotificationPosition.CenterLeft:
-                nativeLeft = nativeWorkArea.Left + nativeMarginX;
-                nativeTop = nativeWorkArea.Top + (nativeWorkArea.Height - nativeHeight) / 2;
-                break;
-            case NotificationPosition.TopLeft:
-                nativeLeft = nativeWorkArea.Left + nativeMarginX;
-                nativeTop = nativeWorkArea.Top + nativeMarginY;
-                break;
-            case NotificationPosition.TopCenter:
-                nativeLeft = nativeWorkArea.Left + (nativeWorkArea.Width - nativeWidth) / 2;
-                nativeTop = nativeWorkArea.Top + nativeMarginY;
-                break;
-            case NotificationPosition.TopRight:
-                nativeLeft = nativeWorkArea.Right - nativeWidth - nativeMarginX;
-                nativeTop = nativeWorkArea.Top + nativeMarginY;
-                break;
-            case NotificationPosition.CenterRight:
-                nativeLeft = nativeWorkArea.Right - nativeWidth - nativeMarginX;
-                nativeTop = nativeWorkArea.Top + (nativeWorkArea.Height - nativeHeight) / 2;
-                break;
-            case NotificationPosition.Center:
-                nativeLeft = nativeWorkArea.Left + (nativeWorkArea.Width - nativeWidth) / 2;
-                nativeTop = nativeWorkArea.Top + (nativeWorkArea.Height - nativeHeight) / 2;
-                break;
+            nativeLeft = -1024768;
+            nativeTop = -1024768;
+        }
+        else
+        {
+            var nativeWidth = Width * multiplierX;
+            var nativeHeight = Height * multiplierY;
+
+            const int margin = 16;
+            var nativeMarginX = margin * multiplierX;
+            var nativeMarginY = margin * multiplierY;
+
+            switch (position)
+            {
+                case NotificationPosition.BottomRight:
+                    nativeLeft = nativeWorkArea.Right - nativeWidth - nativeMarginX;
+                    nativeTop = nativeWorkArea.Bottom - nativeHeight - nativeMarginY;
+                    break;
+                case NotificationPosition.BottomCenter:
+                    nativeLeft = nativeWorkArea.Left + (nativeWorkArea.Width - nativeWidth) / 2;
+                    nativeTop = nativeWorkArea.Bottom - nativeHeight - nativeMarginY;
+                    break;
+                case NotificationPosition.BottomLeft:
+                    nativeLeft = nativeWorkArea.Left + nativeMarginX;
+                    nativeTop = nativeWorkArea.Bottom - nativeHeight - nativeMarginY;
+                    break;
+                case NotificationPosition.CenterLeft:
+                    nativeLeft = nativeWorkArea.Left + nativeMarginX;
+                    nativeTop = nativeWorkArea.Top + (nativeWorkArea.Height - nativeHeight) / 2;
+                    break;
+                case NotificationPosition.TopLeft:
+                    nativeLeft = nativeWorkArea.Left + nativeMarginX;
+                    nativeTop = nativeWorkArea.Top + nativeMarginY;
+                    break;
+                case NotificationPosition.TopCenter:
+                    nativeLeft = nativeWorkArea.Left + (nativeWorkArea.Width - nativeWidth) / 2;
+                    nativeTop = nativeWorkArea.Top + nativeMarginY;
+                    break;
+                case NotificationPosition.TopRight:
+                    nativeLeft = nativeWorkArea.Right - nativeWidth - nativeMarginX;
+                    nativeTop = nativeWorkArea.Top + nativeMarginY;
+                    break;
+                case NotificationPosition.CenterRight:
+                    nativeLeft = nativeWorkArea.Right - nativeWidth - nativeMarginX;
+                    nativeTop = nativeWorkArea.Top + (nativeWorkArea.Height - nativeHeight) / 2;
+                    break;
+                case NotificationPosition.Center:
+                    nativeLeft = nativeWorkArea.Left + (nativeWorkArea.Width - nativeWidth) / 2;
+                    nativeTop = nativeWorkArea.Top + (nativeWorkArea.Height - nativeHeight) / 2;
+                    break;
+            }
         }
 
         var windowInteropHandler = new WindowInteropHelper(this);

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
@@ -109,7 +109,7 @@ public class NotificationWindow : UiWindow, INotificationWindow
 
         var path = new GraphicsPath();
         var rect = new Rectangle(0, 0, newWidth, newHeight);
-        const int diameter = 40;
+        const int diameter = 20;
         path.AddArc(rect.X, rect.Y, diameter, diameter, 180, 90);
         path.AddArc(rect.Right - diameter, rect.Y, diameter, diameter, 270, 90);
         path.AddArc(rect.Right - diameter, rect.Bottom - diameter, diameter, diameter, 0, 90);
@@ -120,7 +120,7 @@ public class NotificationWindow : UiWindow, INotificationWindow
         graphics.DrawImage(bitmap, 0, 0, newWidth, newHeight);
         graphics.ResetClip();
 
-        using var pen = new System.Drawing.Pen(System.Drawing.Color.Gray, 2);
+        using var pen = new System.Drawing.Pen(System.Drawing.Color.FromArgb(64, 64, 64), 2);
         graphics.DrawPath(pen, path);
 
         return resizedBitmap;

--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
@@ -64,7 +64,7 @@ public class NotificationWindow : UiWindow, INotificationWindow
         SourceInitialized += (_, _) => InitializePosition(screenInfo.WorkArea, screenInfo.DpiX, screenInfo.DpiY, position);
         MouseDown += (_, _) =>
         {
-            base.Close();
+            Close();
             clickAction?.Invoke();
         };
     }
@@ -74,7 +74,7 @@ public class NotificationWindow : UiWindow, INotificationWindow
         Show();
         Task.Delay(closeAfter).ContinueWith(_ =>
         {
-            base.Close();
+            Close();
         }, TaskScheduler.FromCurrentSynchronizationContext());
     }
 
@@ -153,8 +153,8 @@ public class NotificationWindow : UiWindow, INotificationWindow
 
         if (_gettingBitMap)
         {
-            nativeLeft = -1024768;
-            nativeTop = -1024768;
+            nativeLeft = -1048576;
+            nativeTop = -1048576;
         }
         else
         {


### PR DESCRIPTION
Closes: #980.
References: #1053.

Replace: #1349.

### Description

Create a C#-implementated AoT OSD window.

The implementation borrows heavily from [g-helper](https://github.com/seerge/g-helper)'s [OSDNativeForm](https://github.com/seerge/g-helper/blob/main/app/Helpers/OSDBase.cs). I changed some things in order to make it more suitable for LLT.

Basically the `NotificationAoTWindow` is only a bitmap carrier. We need to create a bitmap view of a WPF notification window, and then transfer it to the carrier. The problem I had months ago was, I didn't find a way to get the bitmap view without showing the window in foreground. I'm working on it and hope will get a solution soon.

Status update: It seems to only be possible to render the `_mainGrid` element in memory (without showing it). But that's not enough - we need to render the whole window. I did a workaround, which moves the notification to a place definitely out of screen, then call `Show()` and then close it immediately. This is the easiest & the only way I can find.

### TODOs:

- [x] Native layered window encapsulation (`LenovoLegionToolkit.WPF.Windows.Utils.NativeLayeredWindow`)
- [x] AoT notification window (`LenovoLegionToolkit.WPF.Windows.Utils.NotificationAoTWindow`)
- [x] AoT notification window animation
- [ ] ~~Make AoT notification window show over fullscreen games~~
- [x] `NotificationsManager` enhancement
- [x] Create bitmap views of origin notification windows
- [x] Make the bitmap view looks better

### Known Issues:

- The bitmap looks a bit fuzzy after resizing, but I don't think it would be a big deal.

- This way works in most cases: it won't gain focus & shows over most *fullscreen* windows. But I've already noticed that if a game is showing in true *fullscreen* mode, not borderless windowed, this PR won't work, although it won't break anything either. I may give a look how game overlays work.