### PR TITLE
Keep OSD Window No_Activated State on moving Window Position

### DIFF
--- a/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/NotificationWindow.cs
@@ -146,7 +146,7 @@ public class NotificationWindow : UiWindow
 
         var windowInteropHandler = new WindowInteropHelper(this);
 
-        PInvoke.SetWindowPos((HWND)windowInteropHandler.Handle, HWND.Null, (int)nativeLeft, (int)nativeTop, 0, 0, SET_WINDOW_POS_FLAGS.SWP_NOSIZE);
+        PInvoke.SetWindowPos((HWND)windowInteropHandler.Handle, HWND.Null, (int)nativeLeft, (int)nativeTop, 0, 0, SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE);
     }
 
     private void InitializeContent(SymbolRegular symbol, SymbolRegular? overlaySymbol, Action<SymbolIcon>? symbolTransform, string text)


### PR DESCRIPTION
Fix: #1607.

Add `SWP_NOACTIVATE` flag when calling `SetWindowPos` API to keep OSD window focusless.