### PR TITLE
Use display path APIs to change internal display settings, for better 60Hz battery life

### DIFF
--- a/LenovoLegionToolkit.Lib/Features/RefreshRateFeature.cs
+++ b/LenovoLegionToolkit.Lib/Features/RefreshRateFeature.cs
@@ -107,7 +107,7 @@ public class RefreshRateFeature : IFeature<RefreshRate>
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace($"Setting display to {newSettings.ToExtendedString()}...");
 
-            display.SetSettings(newSettings, true);
+            InternalDisplay.SetSettings(newSettings);
 
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace($"Display set to {newSettings.ToExtendedString()}");

--- a/LenovoLegionToolkit.Lib/Features/ResolutionFeature.cs
+++ b/LenovoLegionToolkit.Lib/Features/ResolutionFeature.cs
@@ -108,7 +108,7 @@ public class ResolutionFeature : IFeature<Resolution>
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace($"Setting display to {newSettings.ToExtendedString()}");
 
-            display.SetSettings(newSettings, true);
+            InternalDisplay.SetSettings(newSettings);
 
             if (Log.Instance.IsTraceEnabled)
                 Log.Instance.Trace($"Display set to {newSettings.ToExtendedString()}");

--- a/LenovoLegionToolkit.Lib/System/InternalDisplay.cs
+++ b/LenovoLegionToolkit.Lib/System/InternalDisplay.cs
@@ -74,6 +74,53 @@ public static class InternalDisplay
         }
     }
 
+    public static void SetSettings(DisplaySetting displaySetting)
+    {
+        // Use display path APIs to change internal display resolution & refresh rate.
+        // Compared to Display.SetSettings(), these APIs can change the Active Signal Mode and not just the Desktop mode.
+        // Setting 60Hz will change the Active Signal Mode to 60Hz instead of leaving it at the max refresh rate,
+        // which lets the display consume less power for more battery life.
+        var display = Get();
+        if (display is not null)
+        {
+            var displaySource = display.ToPathDisplaySource();
+            var pathInfos = PathInfo.GetActivePaths();
+            var newPathInfos = new List<PathInfo>();
+
+            foreach (var pathInfo in pathInfos)
+            {
+                if (pathInfo.DisplaySource == displaySource)
+                {
+                    var targetsInfo = pathInfo.TargetsInfo;
+                    var newTargetInfos = new List<PathTargetInfo>();
+
+                    foreach (var targetInfo in targetsInfo)
+                    {
+                        newTargetInfos.Add(new PathTargetInfo(
+                            targetInfo.DisplayTarget,
+                            new PathTargetSignalInfo(displaySetting, displaySetting.Resolution),
+                            targetInfo.Rotation,
+                            targetInfo.Scaling
+                        ));
+                    }
+                    newPathInfos.Add(new PathInfo(
+                        pathInfo.DisplaySource,
+                        pathInfo.Position,
+                        displaySetting.Resolution,
+                        pathInfo.PixelFormat,
+                        newTargetInfos.ToArray()
+                    ));
+                }
+                else
+                {
+                    newPathInfos.Add(pathInfo);
+                }
+            }
+            
+            PathInfo.ApplyPathInfos(newPathInfos.ToArray());
+        }
+    }
+
     private static Display? FindInternalDisplay(IEnumerable<Display> displays)
     {
         return displays.Where(d => d.GetVideoOutputTechnology().IsInternalOutput()).FirstOrDefault();


### PR DESCRIPTION
Using display path APIs instead of `display.SetSettings()` to change internal display refresh rate has a measurable improvement in battery life.

Using `display.SetSettings()` to change to 60Hz: 8.33W battery drain (Active signal mode unchanged)
![ASM165_power](https://github.com/user-attachments/assets/51100885-e573-4c02-9eb6-33744f97fd7c)

Using display path APIs to change to 60Hz: 7.24W battery drain (Active signal mode changed to 60Hz)
![ASM60_power](https://github.com/user-attachments/assets/3238ab32-2ca2-439a-812a-f910e92aa991)

Related to closed issue #1325, but this time I decided to implement this change myself instead of making another issue.