### PR TITLE
Add battery min/max discharge rate and wear level

### DIFF
--- a/LenovoLegionToolkit.Lib/IoCModule.cs
+++ b/LenovoLegionToolkit.Lib/IoCModule.cs
@@ -15,6 +15,7 @@ using LenovoLegionToolkit.Lib.Features.WhiteKeyboardBacklight;
 using LenovoLegionToolkit.Lib.Integrations;
 using LenovoLegionToolkit.Lib.Listeners;
 using LenovoLegionToolkit.Lib.PackageDownloader;
+using LenovoLegionToolkit.Lib.Services;
 using LenovoLegionToolkit.Lib.Settings;
 using LenovoLegionToolkit.Lib.SoftwareDisabler;
 using LenovoLegionToolkit.Lib.Utils;
@@ -132,5 +133,7 @@ public class IoCModule : Module
         builder.Register<HWiNFOIntegration>();
 
         builder.Register<SunriseSunset>();
+
+        builder.Register<BatteryDischargeRateMonitorService>();
     }
 }

--- a/LenovoLegionToolkit.Lib/Services/BatteryDischargeRateMonitorService.cs
+++ b/LenovoLegionToolkit.Lib/Services/BatteryDischargeRateMonitorService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using LenovoLegionToolkit.Lib.System;
+using LenovoLegionToolkit.Lib.Utils;
+
+namespace LenovoLegionToolkit.Lib.Services;
+
+public class BatteryDischargeRateMonitorService
+{
+    private CancellationTokenSource? _cts;
+    private Task? _refreshTask;
+
+    public async Task StartStopIfNeededAsync()
+    {
+        await StopAsync().ConfigureAwait(false);
+
+        if (_refreshTask != null)
+            return;
+
+        _cts?.Cancel();
+        _cts = new CancellationTokenSource();
+
+        var token = _cts.Token;
+
+        _refreshTask = Task.Run(async () =>
+        {
+            if (Log.Instance.IsTraceEnabled)
+                Log.Instance.Trace($"Battery monitoring service started...");
+
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    Battery.SetMinMaxDischargeRate();
+
+                    await Task.Delay(TimeSpan.FromSeconds(3), token);
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception ex)
+                {
+                    if (Log.Instance.IsTraceEnabled)
+                        Log.Instance.Trace($"Battery monitoring service failed.", ex);
+                }
+            }
+
+            if (Log.Instance.IsTraceEnabled)
+                Log.Instance.Trace($"Battery monitoring service stopped.");
+        }, token);
+    }
+
+    public async Task StopAsync()
+    {
+        if (Log.Instance.IsTraceEnabled)
+            Log.Instance.Trace($"Stopping...");
+
+        if (_cts is not null)
+            await _cts.CancelAsync().ConfigureAwait(false);
+
+        _cts = null;
+
+        if (_refreshTask is not null)
+            await _refreshTask.ConfigureAwait(false);
+
+        _refreshTask = null;
+
+        if (Log.Instance.IsTraceEnabled)
+            Log.Instance.Trace($"Stopped.");
+    }
+}

--- a/LenovoLegionToolkit.Lib/Structs.cs
+++ b/LenovoLegionToolkit.Lib/Structs.cs
@@ -18,9 +18,12 @@ public readonly struct BatteryInformation(
     int batteryLifeRemaining,
     int fullBatteryLifeRemaining,
     int dischargeRate,
+    int minDischargeRate,
+    int maxDischargeRate,
     int estimateChargeRemaining,
     int designCapacity,
     int fullChargeCapacity,
+    double wearLevel,
     int cycleCount,
     bool isLowBattery,
     double? batteryTemperatureC,
@@ -32,9 +35,12 @@ public readonly struct BatteryInformation(
     public int BatteryLifeRemaining { get; } = batteryLifeRemaining;
     public int FullBatteryLifeRemaining { get; init; } = fullBatteryLifeRemaining;
     public int DischargeRate { get; } = dischargeRate;
+    public int MinDischargeRate { get; } = minDischargeRate;
+    public int MaxDischargeRate { get; } = maxDischargeRate;
     public int EstimateChargeRemaining { get; } = estimateChargeRemaining;
     public int DesignCapacity { get; } = designCapacity;
     public int FullChargeCapacity { get; } = fullChargeCapacity;
+    public double WearLevel { get; } = wearLevel;
     public int CycleCount { get; } = cycleCount;
     public bool IsLowBattery { get; } = isLowBattery;
     public double? BatteryTemperatureC { get; } = batteryTemperatureC;

--- a/LenovoLegionToolkit.Lib/Structs.cs
+++ b/LenovoLegionToolkit.Lib/Structs.cs
@@ -23,7 +23,6 @@ public readonly struct BatteryInformation(
     int estimateChargeRemaining,
     int designCapacity,
     int fullChargeCapacity,
-    double batteryHealth,
     int cycleCount,
     bool isLowBattery,
     double? batteryTemperatureC,
@@ -40,12 +39,15 @@ public readonly struct BatteryInformation(
     public int EstimateChargeRemaining { get; } = estimateChargeRemaining;
     public int DesignCapacity { get; } = designCapacity;
     public int FullChargeCapacity { get; } = fullChargeCapacity;
-    public double BatteryHealth { get; } = batteryHealth;
     public int CycleCount { get; } = cycleCount;
     public bool IsLowBattery { get; } = isLowBattery;
     public double? BatteryTemperatureC { get; } = batteryTemperatureC;
     public DateTime? ManufactureDate { get; } = manufactureDate;
     public DateTime? FirstUseDate { get; } = firstUseDate;
+    public double BatteryHealth =>
+        DesignCapacity > 0
+        ? Math.Round((double)FullChargeCapacity / DesignCapacity * 100.0, 2, MidpointRounding.AwayFromZero)
+        : 0.0;
 }
 
 public readonly struct BiosVersion(string prefix, int? version)

--- a/LenovoLegionToolkit.Lib/Structs.cs
+++ b/LenovoLegionToolkit.Lib/Structs.cs
@@ -23,7 +23,7 @@ public readonly struct BatteryInformation(
     int estimateChargeRemaining,
     int designCapacity,
     int fullChargeCapacity,
-    double wearLevel,
+    double batteryHealth,
     int cycleCount,
     bool isLowBattery,
     double? batteryTemperatureC,
@@ -40,7 +40,7 @@ public readonly struct BatteryInformation(
     public int EstimateChargeRemaining { get; } = estimateChargeRemaining;
     public int DesignCapacity { get; } = designCapacity;
     public int FullChargeCapacity { get; } = fullChargeCapacity;
-    public double WearLevel { get; } = wearLevel;
+    public double BatteryHealth { get; } = batteryHealth;
     public int CycleCount { get; } = cycleCount;
     public bool IsLowBattery { get; } = isLowBattery;
     public double? BatteryTemperatureC { get; } = batteryTemperatureC;

--- a/LenovoLegionToolkit.Lib/System/Battery.cs
+++ b/LenovoLegionToolkit.Lib/System/Battery.cs
@@ -28,8 +28,8 @@ public static class Battery
         DateTime? manufactureDate = null;
         DateTime? firstUseDate = null;
 
-        double wearLevel = (information.DesignedCapacity > 0)
-                ? (double)(information.DesignedCapacity - information.FullChargedCapacity) / information.DesignedCapacity
+        double batteryHealth = (information.DesignedCapacity > 0)
+                ? (double)information.FullChargedCapacity / information.DesignedCapacity
                 : 0.0;
 
         if (Math.Abs(status.Rate) < Math.Abs(MinDischargeRate))
@@ -69,7 +69,7 @@ public static class Battery
             (int)status.Capacity,
             (int)information.DesignedCapacity,
             (int)information.FullChargedCapacity,
-            Math.Round(wearLevel * 100.0, 2, MidpointRounding.AwayFromZero),
+            Math.Round(batteryHealth * 100.0, 2, MidpointRounding.AwayFromZero),
             (int)information.CycleCount,
             powerStatus.ACLineStatus == 0 && information.DefaultAlert2 >= status.Capacity,
             temperatureC,

--- a/LenovoLegionToolkit.Lib/System/Battery.cs
+++ b/LenovoLegionToolkit.Lib/System/Battery.cs
@@ -53,10 +53,6 @@ public static class Battery
         DateTime? manufactureDate = null;
         DateTime? firstUseDate = null;
 
-        double batteryHealth = (information.DesignedCapacity > 0)
-                ? (double)information.FullChargedCapacity / information.DesignedCapacity
-                : 0.0;
-
         SetMinMaxDischargeRate(status);
 
         try
@@ -85,7 +81,6 @@ public static class Battery
             (int)status.Capacity,
             (int)information.DesignedCapacity,
             (int)information.FullChargedCapacity,
-            Math.Round(batteryHealth * 100.0, 2, MidpointRounding.AwayFromZero),
             (int)information.CycleCount,
             powerStatus.ACLineStatus == 0 && information.DefaultAlert2 >= status.Capacity,
             temperatureC,

--- a/LenovoLegionToolkit.WPF/App.xaml.cs
+++ b/LenovoLegionToolkit.WPF/App.xaml.cs
@@ -23,6 +23,7 @@ using LenovoLegionToolkit.Lib.Features.WhiteKeyboardBacklight;
 using LenovoLegionToolkit.Lib.Integrations;
 using LenovoLegionToolkit.Lib.Listeners;
 using LenovoLegionToolkit.Lib.Macro;
+using LenovoLegionToolkit.Lib.Services;
 using LenovoLegionToolkit.Lib.SoftwareDisabler;
 using LenovoLegionToolkit.Lib.Utils;
 using LenovoLegionToolkit.WPF.CLI;
@@ -137,6 +138,7 @@ public partial class App
         await IoCContainer.Resolve<AIController>().StartIfNeededAsync();
         await IoCContainer.Resolve<HWiNFOIntegration>().StartStopIfNeededAsync();
         await IoCContainer.Resolve<IpcServer>().StartStopIfNeededAsync();
+        await IoCContainer.Resolve<BatteryDischargeRateMonitorService>().StartStopIfNeededAsync();
 
 #if !DEBUG
         Autorun.Validate();
@@ -246,6 +248,15 @@ public partial class App
             if (IoCContainer.TryResolve<IpcServer>() is { } ipcServer)
             {
                 await ipcServer.StopAsync();
+            }
+        }
+        catch { /* Ignored. */ }
+
+        try
+        {
+            if (IoCContainer.TryResolve<BatteryDischargeRateMonitorService>() is { } batteryDischargeMon)
+            {
+                await batteryDischargeMon.StopAsync();
             }
         }
         catch { /* Ignored. */ }

--- a/LenovoLegionToolkit.WPF/Pages/BatteryPage.xaml
+++ b/LenovoLegionToolkit.WPF/Pages/BatteryPage.xaml
@@ -158,12 +158,12 @@
 
         <custom:CardControl Margin="0,0,0,24">
             <custom:CardControl.Header>
-                <controls:CardHeaderControl Title="{x:Static resources:Resource.BatteryPage_WearLevel_Title}" Subtitle="{x:Static resources:Resource.BatteryPage_WearLevel_Message}" />
+                <controls:CardHeaderControl Title="{x:Static resources:Resource.BatteryPage_BatteryHealth_Title}" Subtitle="{x:Static resources:Resource.BatteryPage_BatteryHealth_Message}" />
             </custom:CardControl.Header>
             <TextBlock
-                x:Name="_batteryWearLevelText"
+                x:Name="_batteryHealthText"
                 AutomationProperties.HelpText="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Text}"
-                AutomationProperties.Name="{x:Static resources:Resource.BatteryPage_WearLevel_Title}"
+                AutomationProperties.Name="{x:Static resources:Resource.BatteryPage_BatteryHealth_Title}"
                 FlowDirection="LeftToRight"
                 Focusable="True"
                 FontSize="14" />    

--- a/LenovoLegionToolkit.WPF/Pages/BatteryPage.xaml
+++ b/LenovoLegionToolkit.WPF/Pages/BatteryPage.xaml
@@ -93,6 +93,32 @@
 
         <custom:CardControl Margin="0,0,0,8">
             <custom:CardControl.Header>
+                <controls:CardHeaderControl Title="{x:Static resources:Resource.BatteryPage_MinDischargeRate_Title}" Subtitle="{x:Static resources:Resource.BatteryPage_MinDischargeRate_Message}" />
+            </custom:CardControl.Header>
+            <TextBlock
+                x:Name="_batteryMinDischargeRateText"
+                AutomationProperties.HelpText="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Text}"
+                AutomationProperties.Name="{x:Static resources:Resource.BatteryPage_MinDischargeRate_Title}"
+                FlowDirection="LeftToRight"
+                Focusable="True"
+                FontSize="14" />
+        </custom:CardControl>
+
+        <custom:CardControl Margin="0,0,0,8">
+            <custom:CardControl.Header>
+                <controls:CardHeaderControl Title="{x:Static resources:Resource.BatteryPage_MaxDischargeRate_Title}" Subtitle="{x:Static resources:Resource.BatteryPage_MaxDischargeRate_Message}" />
+            </custom:CardControl.Header>
+            <TextBlock
+                x:Name="_batteryMaxDischargeRateText"
+                AutomationProperties.HelpText="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Text}"
+                AutomationProperties.Name="{x:Static resources:Resource.BatteryPage_MaxDischargeRate_Title}"
+                FlowDirection="LeftToRight"
+                Focusable="True"
+                FontSize="14" />    
+        </custom:CardControl>
+
+        <custom:CardControl Margin="0,0,0,8">
+            <custom:CardControl.Header>
                 <controls:CardHeaderControl Title="{x:Static resources:Resource.BatteryPage_CurrentCapacity_Title}" Subtitle="{x:Static resources:Resource.BatteryPage_CurrentCapacity_Message}" />
             </custom:CardControl.Header>
             <TextBlock
@@ -117,7 +143,7 @@
                 FontSize="14" />
         </custom:CardControl>
 
-        <custom:CardControl Margin="0,0,0,24">
+        <custom:CardControl Margin="0,0,0,8">
             <custom:CardControl.Header>
                 <controls:CardHeaderControl Title="{x:Static resources:Resource.BatteryPage_DesignCapacity_Title}" Subtitle="{x:Static resources:Resource.BatteryPage_DesignCapacity_Message}" />
             </custom:CardControl.Header>
@@ -128,6 +154,19 @@
                 FlowDirection="LeftToRight"
                 Focusable="True"
                 FontSize="14" />
+        </custom:CardControl>
+
+        <custom:CardControl Margin="0,0,0,24">
+            <custom:CardControl.Header>
+                <controls:CardHeaderControl Title="{x:Static resources:Resource.BatteryPage_WearLevel_Title}" Subtitle="{x:Static resources:Resource.BatteryPage_WearLevel_Message}" />
+            </custom:CardControl.Header>
+            <TextBlock
+                x:Name="_batteryWearLevelText"
+                AutomationProperties.HelpText="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Text}"
+                AutomationProperties.Name="{x:Static resources:Resource.BatteryPage_WearLevel_Title}"
+                FlowDirection="LeftToRight"
+                Focusable="True"
+                FontSize="14" />    
         </custom:CardControl>
 
         <custom:CardControl Margin="0,0,0,8">

--- a/LenovoLegionToolkit.WPF/Pages/BatteryPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/BatteryPage.xaml.cs
@@ -124,9 +124,12 @@ public partial class BatteryPage
         }
 
         _batteryDischargeRateText.Text = $"{batteryInfo.DischargeRate / 1000.0:+0.00;-0.00;0.00} W";
+        _batteryMinDischargeRateText.Text = $"{batteryInfo.MinDischargeRate / 1000.0:+0.00;-0.00;0.00} W";
+        _batteryMaxDischargeRateText.Text = $"{batteryInfo.MaxDischargeRate / 1000.0:+0.00;-0.00;0.00} W";
         _batteryCapacityText.Text = $"{batteryInfo.EstimateChargeRemaining / 1000.0:0.00} Wh";
         _batteryFullChargeCapacityText.Text = $"{batteryInfo.FullChargeCapacity / 1000.0:0.00} Wh";
         _batteryDesignCapacityText.Text = $"{batteryInfo.DesignCapacity / 1000.0:0.00} Wh";
+        _batteryWearLevelText.Text = $"{batteryInfo.WearLevel:0.00} %";
 
         if (batteryInfo.ManufactureDate is not null)
             _batteryManufactureDateText.Text = batteryInfo.ManufactureDate?.ToString(LocalizationHelper.ShortDateFormat) ?? "-";

--- a/LenovoLegionToolkit.WPF/Pages/BatteryPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/BatteryPage.xaml.cs
@@ -129,7 +129,7 @@ public partial class BatteryPage
         _batteryCapacityText.Text = $"{batteryInfo.EstimateChargeRemaining / 1000.0:0.00} Wh";
         _batteryFullChargeCapacityText.Text = $"{batteryInfo.FullChargeCapacity / 1000.0:0.00} Wh";
         _batteryDesignCapacityText.Text = $"{batteryInfo.DesignCapacity / 1000.0:0.00} Wh";
-        _batteryWearLevelText.Text = $"{batteryInfo.WearLevel:0.00} %";
+        _batteryHealthText.Text = $"{batteryInfo.BatteryHealth:0.00} %";
 
         if (batteryInfo.ManufactureDate is not null)
             _batteryManufactureDateText.Text = batteryInfo.ManufactureDate?.ToString(LocalizationHelper.ShortDateFormat) ?? "-";

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -746,6 +746,24 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Battery maximum charge capacity..
+        /// </summary>
+        public static string BatteryPage_BatteryHealth_Message {
+            get {
+                return ResourceManager.GetString("BatteryPage_BatteryHealth_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Battery health.
+        /// </summary>
+        public static string BatteryPage_BatteryHealth_Title {
+            get {
+                return ResourceManager.GetString("BatteryPage_BatteryHealth_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Current temperature of the battery..
         /// </summary>
         public static string BatteryPage_BatteryTemperature_Message {
@@ -986,24 +1004,6 @@ namespace LenovoLegionToolkit.WPF.Resources {
         public static string BatteryPage_Title {
             get {
                 return ResourceManager.GetString("BatteryPage_Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Battery wear level..
-        /// </summary>
-        public static string BatteryPage_WearLevel_Message {
-            get {
-                return ResourceManager.GetString("BatteryPage_WearLevel_Message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Wear level.
-        /// </summary>
-        public static string BatteryPage_WearLevel_Title {
-            get {
-                return ResourceManager.GetString("BatteryPage_WearLevel_Title", resourceCulture);
             }
         }
         

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -926,6 +926,42 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Maximum rate at which battery is charged (+), or discharged (-)..
+        /// </summary>
+        public static string BatteryPage_MaxDischargeRate_Message {
+            get {
+                return ResourceManager.GetString("BatteryPage_MaxDischargeRate_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum discharge rate.
+        /// </summary>
+        public static string BatteryPage_MaxDischargeRate_Title {
+            get {
+                return ResourceManager.GetString("BatteryPage_MaxDischargeRate_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minimum rate at which battery is charged (+), or discharged (-)..
+        /// </summary>
+        public static string BatteryPage_MinDischargeRate_Message {
+            get {
+                return ResourceManager.GetString("BatteryPage_MinDischargeRate_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minimum discharge rate.
+        /// </summary>
+        public static string BatteryPage_MinDischargeRate_Title {
+            get {
+                return ResourceManager.GetString("BatteryPage_MinDischargeRate_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Time since laptop was last connected to AC power.
         ///This time might not be accurate, if laptop was charged when sleeping or off..
         /// </summary>
@@ -950,6 +986,24 @@ namespace LenovoLegionToolkit.WPF.Resources {
         public static string BatteryPage_Title {
             get {
                 return ResourceManager.GetString("BatteryPage_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Battery wear level..
+        /// </summary>
+        public static string BatteryPage_WearLevel_Message {
+            get {
+                return ResourceManager.GetString("BatteryPage_WearLevel_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Wear level.
+        /// </summary>
+        public static string BatteryPage_WearLevel_Title {
+            get {
+                return ResourceManager.GetString("BatteryPage_WearLevel_Title", resourceCulture);
             }
         }
         
@@ -5857,6 +5911,24 @@ namespace LenovoLegionToolkit.WPF.Resources {
         public static string StatusTrayPopup_DiscreteGPU {
             get {
                 return ResourceManager.GetString("StatusTrayPopup_DiscreteGPU", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max discharge rate.
+        /// </summary>
+        public static string StatusTrayPopup_MaxDischargeRate {
+            get {
+                return ResourceManager.GetString("StatusTrayPopup_MaxDischargeRate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Min discharge rate.
+        /// </summary>
+        public static string StatusTrayPopup_MinDischargeRate {
+            get {
+                return ResourceManager.GetString("StatusTrayPopup_MinDischargeRate", resourceCulture);
             }
         }
         

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -365,11 +365,11 @@ Only actions that match current state will run.</value>
   <data name="BatteryPage_FullChargeCapacity_Title" xml:space="preserve">
     <value>Full charge capacity</value>
   </data>
-  <data name="BatteryPage_WearLevel_Message" xml:space="preserve">
-    <value>Battery wear level.</value>
+  <data name="BatteryPage_BatteryHealth_Message" xml:space="preserve">
+    <value>Battery maximum charge capacity.</value>
   </data>
-  <data name="BatteryPage_WearLevel_Title" xml:space="preserve">
-    <value>Wear level</value>
+  <data name="BatteryPage_BatteryHealth_Title" xml:space="preserve">
+    <value>Battery health</value>
   </data>
   <data name="BatteryPage_LowWattageChargerConnected" xml:space="preserve">
     <value>Low wattage charger connected</value>

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -335,6 +335,18 @@ Only actions that match current state will run.</value>
   <data name="BatteryPage_DischargeRate_Title" xml:space="preserve">
     <value>Discharge rate</value>
   </data>
+  <data name="BatteryPage_MinDischargeRate_Message" xml:space="preserve">
+    <value>Minimum rate at which battery is charged (+), or discharged (-).</value>
+  </data>
+  <data name="BatteryPage_MinDischargeRate_Title" xml:space="preserve">
+    <value>Minimum discharge rate</value>
+  </data>
+  <data name="BatteryPage_MaxDischargeRate_Message" xml:space="preserve">
+    <value>Maximum rate at which battery is charged (+), or discharged (-).</value>
+  </data>
+  <data name="BatteryPage_MaxDischargeRate_Title" xml:space="preserve">
+    <value>Maximum discharge rate</value>
+  </data>
   <data name="BatteryPage_EstimatedBatteryLifeRemaining" xml:space="preserve">
     <value>Estimated time remaining: {0}</value>
   </data>
@@ -352,6 +364,12 @@ Only actions that match current state will run.</value>
   </data>
   <data name="BatteryPage_FullChargeCapacity_Title" xml:space="preserve">
     <value>Full charge capacity</value>
+  </data>
+  <data name="BatteryPage_WearLevel_Message" xml:space="preserve">
+    <value>Battery wear level.</value>
+  </data>
+  <data name="BatteryPage_WearLevel_Title" xml:space="preserve">
+    <value>Wear level</value>
   </data>
   <data name="BatteryPage_LowWattageChargerConnected" xml:space="preserve">
     <value>Low wattage charger connected</value>
@@ -1666,6 +1684,12 @@ This settings takes effect only when Custom Mode is enabled.</value>
   </data>
   <data name="StatusTrayPopup_DischargeRate" xml:space="preserve">
     <value>Discharge rate</value>
+  </data>
+  <data name="StatusTrayPopup_MinDischargeRate" xml:space="preserve">
+    <value>Min discharge rate</value>
+  </data>
+  <data name="StatusTrayPopup_MaxDischargeRate" xml:space="preserve">
+    <value>Max discharge rate</value>
   </data>
   <data name="StatusTrayPopup_UpdateAvailable" xml:space="preserve">
     <value>Update available!</value>

--- a/LenovoLegionToolkit.WPF/Resources/Resource.vi.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.vi.resx
@@ -365,11 +365,11 @@ Chỉ có các Hành động thỏa điều kiện hiện tại sẽ được ch
   <data name="BatteryPage_FullChargeCapacity_Title" xml:space="preserve">
     <value>Dung lượng tối đa</value>
   </data>
-  <data name="BatteryPage_WearLevel_Message" xml:space="preserve">
-    <value>Mức độ chai pin.</value>
+  <data name="BatteryPage_BatteryHealth_Message" xml:space="preserve">
+    <value>Dung lượng sạc tối đa của pin.</value>
   </data>
-  <data name="BatteryPage_WearLevel_Title" xml:space="preserve">
-    <value>Chai pin</value>
+  <data name="BatteryPage_BatteryHealth_Title" xml:space="preserve">
+    <value>Tình trạng pin</value>
   </data>
   <data name="BatteryPage_LowWattageChargerConnected" xml:space="preserve">
     <value>Sạc công suất thấp được kết nối</value>

--- a/LenovoLegionToolkit.WPF/Resources/Resource.vi.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.vi.resx
@@ -335,6 +335,18 @@ Chỉ có các Hành động thỏa điều kiện hiện tại sẽ được ch
   <data name="BatteryPage_DischargeRate_Title" xml:space="preserve">
     <value>Tốc độ sạc/xả</value>
   </data>
+  <data name="BatteryPage_MinDischargeRate_Message" xml:space="preserve">
+    <value>Tốc độ pin sạc (+), hoặc xả (-) thấp nhất.</value>
+  </data>
+  <data name="BatteryPage_MinDischargeRate_Title" xml:space="preserve">
+    <value>Tốc độ sạc/xả thấp nhất</value>
+  </data>
+  <data name="BatteryPage_MaxDischargeRate_Message" xml:space="preserve">
+    <value>Tốc độ pin sạc (+), hoặc xả (-) cao nhất.</value>
+  </data>
+  <data name="BatteryPage_MaxDischargeRate_Title" xml:space="preserve">
+    <value>Tốc độ sạc/xả cao nhất</value>
+  </data>
   <data name="BatteryPage_EstimatedBatteryLifeRemaining" xml:space="preserve">
     <value>Ước tính thời gian dùng còn lại: {0}</value>
   </data>
@@ -352,6 +364,12 @@ Chỉ có các Hành động thỏa điều kiện hiện tại sẽ được ch
   </data>
   <data name="BatteryPage_FullChargeCapacity_Title" xml:space="preserve">
     <value>Dung lượng tối đa</value>
+  </data>
+  <data name="BatteryPage_WearLevel_Message" xml:space="preserve">
+    <value>Mức độ chai pin.</value>
+  </data>
+  <data name="BatteryPage_WearLevel_Title" xml:space="preserve">
+    <value>Chai pin</value>
   </data>
   <data name="BatteryPage_LowWattageChargerConnected" xml:space="preserve">
     <value>Sạc công suất thấp được kết nối</value>
@@ -1666,6 +1684,12 @@ Chỉ hoạt động khi chế độ Tùy Chỉnh đang bật.</value>
   </data>
   <data name="StatusTrayPopup_DischargeRate" xml:space="preserve">
     <value>Tốc độ sạc/xả</value>
+  </data>
+  <data name="StatusTrayPopup_MinDischargeRate" xml:space="preserve">
+    <value>Tốc độ sạc/xả thấp nhất</value>
+  </data>
+  <data name="StatusTrayPopup_MaxDischargeRate" xml:space="preserve">
+    <value>Tốc độ sạc/xả cao nhất</value>
   </data>
   <data name="StatusTrayPopup_UpdateAvailable" xml:space="preserve">
     <value>Có bản cập nhật mới!</value>

--- a/LenovoLegionToolkit.WPF/Windows/Utils/StatusWindow.xaml
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/StatusWindow.xaml
@@ -217,6 +217,8 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <wpfui:SymbolIcon
@@ -275,6 +277,42 @@
             <Label
                 x:Name="_batteryDischargeValueLabel"
                 Grid.Row="2"
+                Grid.Column="3"
+                Margin="16,4,0,0"
+                HorizontalAlignment="Right"
+                FlowDirection="LeftToRight"
+                FontSize="{StaticResource SecondaryFontSize}"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
+            <Label
+                Grid.Row="3"
+                Grid.Column="1"
+                Margin="8,4,0,0"
+                VerticalContentAlignment="Center"
+                Content="{x:Static resources:Resource.StatusTrayPopup_MinDischargeRate}"
+                FontSize="{StaticResource SecondaryFontSize}"
+                FontWeight="Medium"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
+            <Label
+                x:Name="_batteryMinDischargeValueLabel"
+                Grid.Row="3"
+                Grid.Column="3"
+                Margin="16,4,0,0"
+                HorizontalAlignment="Right"
+                FlowDirection="LeftToRight"
+                FontSize="{StaticResource SecondaryFontSize}"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
+            <Label
+                Grid.Row="4"
+                Grid.Column="1"
+                Margin="8,4,0,0"
+                VerticalContentAlignment="Center"
+                Content="{x:Static resources:Resource.StatusTrayPopup_MaxDischargeRate}"
+                FontSize="{StaticResource SecondaryFontSize}"
+                FontWeight="Medium"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
+            <Label
+                x:Name="_batteryMaxDischargeValueLabel"
+                Grid.Row="4"
                 Grid.Column="3"
                 Margin="16,4,0,0"
                 HorizontalAlignment="Right"

--- a/LenovoLegionToolkit.WPF/Windows/Utils/StatusWindow.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/StatusWindow.xaml.cs
@@ -229,6 +229,8 @@ public partial class StatusWindow
             _batteryValueLabel.Content = "-";
             _batteryModeValueLabel.Content = "-";
             _batteryDischargeValueLabel.Content = "-";
+            _batteryMinDischargeValueLabel.Content = "-";
+            _batteryMaxDischargeValueLabel.Content = "-";
             return;
         }
 
@@ -257,6 +259,8 @@ public partial class StatusWindow
         _batteryValueLabel.Content = $"{batteryInformation.Value.BatteryPercentage}%";
         _batteryModeValueLabel.Content = batteryState.GetDisplayName();
         _batteryDischargeValueLabel.Content = $"{batteryInformation.Value.DischargeRate / 1000.0:+0.00;-0.00;0.00} W";
+        _batteryMinDischargeValueLabel.Content = $"{batteryInformation.Value.MinDischargeRate / 1000.0:+0.00;-0.00;0.00} W";
+        _batteryMaxDischargeValueLabel.Content = $"{batteryInformation.Value.MaxDischargeRate / 1000.0:+0.00;-0.00;0.00} W";
     }
 
     private void RefreshUpdate(bool hasUpdate) => _updateIndicator.Visibility = hasUpdate ? Visibility.Visible : Visibility.Collapsed;


### PR DESCRIPTION
Added features:

- Battery wear level, min and max discharge rate.
- Updates the BatteryInformation struct and logic to track and display these new metrics.
- Modifies the UI (BatteryPage.xaml, StatusWindow) to show minimum/maximum discharge rates and wear level.
- Add localization for Vietnamese.

![image](https://github.com/user-attachments/assets/1a461bc2-4eb5-4fed-9351-03cd80f98071)
![image](https://github.com/user-attachments/assets/28c95b5b-a0e9-4bfd-8ead-91f8a245404f)

Personally, I do monitor battery when off the wall a lots, so these changes would save me few steps from calculating them on my own.